### PR TITLE
Handle DistributionNotFound when getting version

### DIFF
--- a/cheroot/__init__.py
+++ b/cheroot/__init__.py
@@ -1,5 +1,5 @@
 try:
 	import pkg_resources
 	__version__ = pkg_resources.get_distribution('cheroot').version
-except ImportError:
+except (ImportError, pkg_resources.DistributionNotFound):
 	__version__ = 'unknown'


### PR DESCRIPTION
When frozen with e.g. cx_Freeze, cheroot will be importable, but not discoverable by pkg_resources.