### PR TITLE
Catch known built-in SSL provider errors

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,9 @@
+v5.2.0
+======
+
+Prevent tracebacks and drop bad HTTPS connections in the
+``BuiltinSSLAdapter``, similar to ``pyOpenSSLAdapter``.
+
 v5.1.0
 ======
 

--- a/cheroot/ssl/builtin.py
+++ b/cheroot/ssl/builtin.py
@@ -85,10 +85,16 @@ class BuiltinSSLAdapter(Adapter):
                 if 'http request' in e.args[1]:
                     # The client is speaking HTTP to an HTTPS server.
                     raise errors.NoSSLError
-                elif 'unknown protocol' in e.args[1]:
-                    # The client is speaking some non-HTTP protocol.
-                    # Drop the conn.
-                    return None, {}
+                
+                # Check if it's one of the known errors
+                # Errors that are caught by PyOpenSSL, but thrown by built-in ssl
+                _block_errors = ('unknown protocol', 'unknown ca', 'unknown_ca',
+                                 'inappropriate fallback', 'wrong version number',
+                                 'no shared cipher', 'certificate unknown', 'ccs received early')
+                for error_text in _block_errors:
+                    if error_text in e.args[1].lower():
+                        # Accepted error, let's pass
+                        return None, {}
             elif 'handshake operation timed out' in e.args[0]:
                 # This error is thrown by builtin SSL after a timeout
                 # when client is speaking HTTP to an HTTPS server.


### PR DESCRIPTION
We (well, our users) have been using CherryPy with the built-in SSL module quite extensively and a number of errors have come up that are thrown by the built-in provider that can just be ignored.
Using the `pyopenssl` module, these are caught by `pyopenssl`, but not by `ssl`.

An easy example is running the http://testssl.sh/ script against a CherryPy server that uses the built-in provider with any type of certificates.

Maybe we can add some logging about dropped connections to the access log? I wasn't sure, because nowhere in these modules the logging is used.