### PR TITLE
add attribute "ciphers" to ssladapter

### DIFF
--- a/cheroot/ssl/__init__.py
+++ b/cheroot/ssl/__init__.py
@@ -9,10 +9,11 @@ class Adapter(object):
           socket file object``
     """
 
-    def __init__(self, certificate, private_key, certificate_chain=None):
+    def __init__(self, certificate, private_key, certificate_chain=None, ciphers=None):
         self.certificate = certificate
         self.private_key = private_key
         self.certificate_chain = certificate_chain
+        self.ciphers = ciphers
 
     def wrap(self, sock):
         raise NotImplemented

--- a/cheroot/ssl/builtin.py
+++ b/cheroot/ssl/builtin.py
@@ -59,7 +59,7 @@ class BuiltinSSLAdapter(Adapter):
                 cafile=certificate_chain
             )
             self.context.load_cert_chain(certificate, private_key)
-            if(self.ciphers != None):
+            if self.ciphers is not None:
                 self.context.set_ciphers(ciphers)
 
     def bind(self, sock):

--- a/cheroot/ssl/builtin.py
+++ b/cheroot/ssl/builtin.py
@@ -50,10 +50,9 @@ class BuiltinSSLAdapter(Adapter):
     def __init__(self, certificate, private_key, certificate_chain=None, ciphers=None):
         if ssl is None:
             raise ImportError('You must install the ssl module to use HTTPS.')
-        self.certificate = certificate
-        self.private_key = private_key
-        self.certificate_chain = certificate_chain
-        self.ciphers=None
+
+        super(BuiltinSSLAdapter, self).__init__(certificate, private_key, certificate_chain, ciphers)
+
         if hasattr(ssl, 'create_default_context'):
             self.context = ssl.create_default_context(
                 purpose=ssl.Purpose.CLIENT_AUTH,

--- a/cheroot/ssl/builtin.py
+++ b/cheroot/ssl/builtin.py
@@ -43,20 +43,25 @@ class BuiltinSSLAdapter(Adapter):
     """The ssl.SSLContext that will be used to wrap sockets where available
     (on Python > 2.7.9 / 3.3)
     """
+    ciphers = None
+    """The ciphers list of SSL."""
     context = None
 
-    def __init__(self, certificate, private_key, certificate_chain=None):
+    def __init__(self, certificate, private_key, certificate_chain=None, ciphers=None):
         if ssl is None:
             raise ImportError('You must install the ssl module to use HTTPS.')
         self.certificate = certificate
         self.private_key = private_key
         self.certificate_chain = certificate_chain
+        self.ciphers=None
         if hasattr(ssl, 'create_default_context'):
             self.context = ssl.create_default_context(
                 purpose=ssl.Purpose.CLIENT_AUTH,
                 cafile=certificate_chain
             )
             self.context.load_cert_chain(certificate, private_key)
+            if(self.ciphers != None):
+                self.context.set_ciphers(ciphers)
 
     def bind(self, sock):
         """Wrap and return the given socket."""

--- a/cheroot/ssl/builtin.py
+++ b/cheroot/ssl/builtin.py
@@ -28,7 +28,6 @@ from ..makefile import MakeFile
 
 
 class BuiltinSSLAdapter(Adapter):
-
     """A wrapper for integrating Python's builtin ssl module with CherryPy."""
 
     certificate = None
@@ -40,14 +39,16 @@ class BuiltinSSLAdapter(Adapter):
     certificate_chain = None
     """The filename of the certificate chain file."""
 
+    context = None
     """The ssl.SSLContext that will be used to wrap sockets where available
     (on Python > 2.7.9 / 3.3)
     """
+
     ciphers = None
     """The ciphers list of SSL."""
-    context = None
 
     def __init__(self, certificate, private_key, certificate_chain=None, ciphers=None):
+        """Set up context and ciphers in addition to base class properties if available."""
         if ssl is None:
             raise ImportError('You must install the ssl module to use HTTPS.')
 
@@ -122,4 +123,5 @@ class BuiltinSSLAdapter(Adapter):
         return ssl_environ
 
     def makefile(self, sock, mode='r', bufsize=DEFAULT_BUFFER_SIZE):
+        """Return socket file object."""
         return MakeFile(sock, mode, bufsize)

--- a/cheroot/ssl/pyopenssl.py
+++ b/cheroot/ssl/pyopenssl.py
@@ -171,10 +171,9 @@ class pyOpenSSLAdapter(Adapter):
         if SSL is None:
             raise ImportError('You must install pyOpenSSL to use HTTPS.')
 
+        super(pyOpenSSLAdapter, self).__init__(certificate, private_key, certificate_chain)
+
         self.context = None
-        self.certificate = certificate
-        self.private_key = private_key
-        self.certificate_chain = certificate_chain
         self._environ = None
 
     def bind(self, sock):


### PR DESCRIPTION
Hi Team,
Our security team got a request recently, need to dynamiclly set cipher suites of https connections.
Since Python(version >= 2.7.9)support "context.set_ciphers()", then we can add attribute "ssl_ciphers", and transfer it to "ssl_builtin.py". Thus, if cherrypy use builtin ssl lib, it can dynamicly configure the cipher suites.

I have a solution to add the attribute, could you please merge it once you pass the review?

Thanks,
Cindy