### PR TITLE
Catch "Protocol wrong type for socket" on OSX also for non-blocking sockets

### DIFF
--- a/cheroot/errors.py
+++ b/cheroot/errors.py
@@ -46,8 +46,9 @@ socket_errors_to_ignore = plat_specific_errors(
 )
 socket_errors_to_ignore.append('timed out')
 socket_errors_to_ignore.append('The read operation timed out')
-if sys.platform == 'darwin':
-    socket_errors_to_ignore.append(plat_specific_errors('EPROTOTYPE'))
-
 socket_errors_nonblocking = plat_specific_errors(
     'EAGAIN', 'EWOULDBLOCK', 'WSAEWOULDBLOCK')
+
+if sys.platform == 'darwin':
+    socket_errors_to_ignore.append(plat_specific_errors('EPROTOTYPE'))
+    socket_errors_nonblocking.append(plat_specific_errors('EPROTOTYPE'))


### PR DESCRIPTION
This was originally fixed for regular sockets in https://github.com/cherrypy/cherrypy/issues/1392
But it seems it can also occur during the sending on non-blocking sockets https://forums.sabnzbd.org/viewtopic.php?f=2&t=22728&p=112251

This is on our build-in CP 8.1.2, but since the code seems identical it can occur in any CP version.
Code section is now here: https://github.com/cherrypy/cheroot/blob/master/cheroot/makefile.py#L55-L63