### PR TITLE
Add more built-in SSL errors to ignore

### DIFF
--- a/cheroot/ssl/builtin.py
+++ b/cheroot/ssl/builtin.py
@@ -90,8 +90,8 @@ class BuiltinSSLAdapter(Adapter):
 
                 # Check if it's one of the known errors
                 # Errors that are caught by PyOpenSSL, but thrown by built-in ssl
-                _block_errors = ('unknown protocol', 'unknown ca', 'unknown_ca',
-                                 'inappropriate fallback', 'wrong version number',
+                _block_errors = ('unknown protocol', 'unknown ca', 'unknown_ca', 'unknown error',
+                                 'https proxy request', 'inappropriate fallback', 'wrong version number',
                                  'no shared cipher', 'certificate unknown', 'ccs received early')
                 for error_text in _block_errors:
                     if error_text in ex.args[1].lower():


### PR DESCRIPTION
Users have reported these 2 new errors that get thrown specifically by the built-in SSL provider compared to PyOpenSSL.

* `unknown error`: If testing a CherryPy server using https://testssl.sh/: https://github.com/sabnzbd/sabnzbd/issues/820#issuecomment-281463671
* `https proxy request`: When someone tries to use a CherryPy server as a Proxy server: https://github.com/sabnzbd/sabnzbd/issues/860