### PR TITLE
Catch error of builtin ssl when used with newest OpenSSL

### DIFF
--- a/cheroot/ssl/builtin.py
+++ b/cheroot/ssl/builtin.py
@@ -90,7 +90,7 @@ class BuiltinSSLAdapter(Adapter):
 
                 # Check if it's one of the known errors
                 # Errors that are caught by PyOpenSSL, but thrown by built-in ssl
-                _block_errors = ('unknown protocol', 'unknown ca', 'unknown_ca', 'unknown error',
+                _block_errors = ('unknown protocol', 'unknown ca', 'unknown error', 'errno 0',
                                  'https proxy request', 'inappropriate fallback', 'wrong version number',
                                  'no shared cipher', 'certificate unknown', 'ccs received early')
                 for error_text in _block_errors:


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix


* **What is the related issue number (starting with `#`)**

https://github.com/sabnzbd/sabnzbd/issues/853
https://forums.sabnzbd.org/viewtopic.php?f=3&t=22425&p=112784#p112778


* **What is the current behavior?** (You can also link to an open issue here)

When using the builtin SSL provider in Python 2 but with a new version of OpenSSL (1.10) that is not *really* supported by Python 2, this error will be thrown but connections will then later still work.