### PR TITLE
Correctly catch EPROTOTYPE on macOS

### DIFF
--- a/cheroot/errors.py
+++ b/cheroot/errors.py
@@ -51,5 +51,5 @@ socket_errors_nonblocking = plat_specific_errors(
     'EAGAIN', 'EWOULDBLOCK', 'WSAEWOULDBLOCK')
 
 if sys.platform == 'darwin':
-    socket_errors_to_ignore.append(plat_specific_errors('EPROTOTYPE'))
-    socket_errors_nonblocking.append(plat_specific_errors('EPROTOTYPE'))
+    socket_errors_to_ignore.extend(plat_specific_errors('EPROTOTYPE'))
+    socket_errors_nonblocking.extend(plat_specific_errors('EPROTOTYPE'))


### PR DESCRIPTION
@webknjaz @The-Compiler 
A helpful user that got this error a lot debugged this for me. 
`cheroot.errors.plat_specific_errors('EPROTOTYPE')` produces an array, so appending an array to an array gives...
```
socket_errors_nonblocking = [35, [41]]
```
So seems to me the original patch never worked either?