### PR TITLE
Don't use SO_REUSEADDR on Windows

### DIFF
--- a/cheroot/server.py
+++ b/cheroot/server.py
@@ -1545,6 +1545,7 @@ class HTTPServer(object):
         self.socket = socket.socket(family, type, proto)
         prevent_socket_inheritance(self.socket)
         # Windows have different semantics for SO_REUSEADDR, so don't set it there.
+        # https://msdn.microsoft.com/en-us/library/ms740621(v=vs.85).aspx
         if 'win' not in sys.platform:
             self.socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
         if self.nodelay and not isinstance(self.bind_addr, str):

--- a/cheroot/server.py
+++ b/cheroot/server.py
@@ -1544,6 +1544,7 @@ class HTTPServer(object):
         """Create (or recreate) the actual socket object."""
         self.socket = socket.socket(family, type, proto)
         prevent_socket_inheritance(self.socket)
+        # Windows have different semantics for SO_REUSEADDR, so don't set it there.
         if 'win' not in sys.platform:
             self.socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
         if self.nodelay and not isinstance(self.bind_addr, str):

--- a/cheroot/server.py
+++ b/cheroot/server.py
@@ -1544,7 +1544,8 @@ class HTTPServer(object):
         """Create (or recreate) the actual socket object."""
         self.socket = socket.socket(family, type, proto)
         prevent_socket_inheritance(self.socket)
-        self.socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        if 'win' not in sys.platform:
+            self.socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
         if self.nodelay and not isinstance(self.bind_addr, str):
             self.socket.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
 


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix(?)

* **What is the related issue number (starting with `#`)**

cherrypy/cherrypy#1088

* **What is the current behavior?** (You can also link to an open issue here)

To bind using SO_REUSEADDR on all platforms

* **What is the new behavior (if this is a feature change)?**

To not bind using SO_REUSEADDR on Windows.

* **Other information**:
https://msdn.microsoft.com/en-us/library/ms740621(v=vs.85).aspx