### PR TITLE
Drop support for Python 2.6, 3.1, 3.2, and 3.3. Also Python <2.7.9

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,4 +6,4 @@ jobs:
     steps:
     - checkout
     - run: pip install tox
-    - run: tox -e py27,py33,py34,py35,py36
+    - run: tox -e py27,py34,py35,py36

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,7 @@ sudo: false
 language: python
 
 python:
-- 2.6
 - 2.7
-- 3.3
 - 3.4
 - 3.5
 - &pypy2 pypy2.7-5.8.0
@@ -90,23 +88,9 @@ jobs:
     python: nightly
   - <<: *osx_python_base
     <<: *manual_run_or_cron
-    python: 2.6
-    env:
-    - PYTHON_VERSION=2.6.9
-    - *env_pyenv
-    - *env_path
-  - <<: *osx_python_base
-    <<: *manual_run_or_cron
     python: 2.7
     env:
     - PYTHON_VERSION=2.7.13
-    - *env_pyenv
-    - *env_path
-  - <<: *osx_python_base
-    <<: *manual_run_or_cron
-    python: 3.3
-    env:
-    - PYTHON_VERSION=3.3.6
     - *env_pyenv
     - *env_path
   - <<: *osx_python_base

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,8 @@ v6.0.0
 ======
 
 - Drop support for Python 2.6, 3.1, 3.2, and 3.3.
+- Also drop built-in SSL support for Python 2.7 earlier
+  than 2.7.9.
 
 v5.10.0
 ======

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,8 @@
+v6.0.0
+======
+
+- Drop support for Python 2.6, 3.1, 3.2, and 3.3.
+
 v5.10.0
 ======
 

--- a/cheroot/makefile.py
+++ b/cheroot/makefile.py
@@ -2,12 +2,7 @@
 
 import socket
 
-try:
-    # prefer slower Python-based io module
-    import _pyio as io
-except ImportError:
-    # Python 2.6
-    import io
+import _pyio as io
 
 import six
 

--- a/cheroot/test/webtest.py
+++ b/cheroot/test/webtest.py
@@ -28,6 +28,8 @@ from imp import reload
 from six.moves import range, http_client, map, urllib_parse
 import six
 
+from more_itertools.more import always_iterable
+
 
 def interface(host):
     """Return an IP address for a client connection given the server host.
@@ -647,22 +649,3 @@ def server_error(exc=None):
         print('')
         print(''.join(traceback.format_exception(*exc)))
         return True
-
-
-def always_iterable(obj, base_type=(six.text_type, six.binary_type)):
-    """
-    Copy of always_iterable from more_itertools.more.
-
-    Replace with dependency when Python 2.6 compatibility is
-    no longer required.
-    """
-    if obj is None:
-        return iter(())
-
-    if (base_type is not None) and isinstance(obj, base_type):
-        return iter((obj,))
-
-    try:
-        return iter(obj)
-    except TypeError:
-        return iter((obj,))

--- a/setup.py
+++ b/setup.py
@@ -32,9 +32,10 @@ params = dict(
         name.split('.')[:-1] if nspkg_technique == 'managed'
         else []
     ),
-    python_requires='>=2.6,!=3.0.*',
+    python_requires='>=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*',
     install_requires=[
         'six>=1.11.0',
+        'more_itertools>=2.6',
     ],
     extras_require={
         'docs': [
@@ -72,12 +73,8 @@ params = dict(
         'License :: OSI Approved :: BSD License',
         'Programming Language :: Python',
         'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.1',
-        'Programming Language :: Python :: 3.2',
-        'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',


### PR DESCRIPTION
I thought I'd submitted a PR for this but now I don't see one.

This request removes support for Python 2.7.8 and earlier on Python 2 and Python 3.2 on Python 3.

Removing support for older Pythons simplifies the code-base and gets us one step closer to supporting only Python 3.

These changes will also simplify the SSL story by supporting only the preferred SSLContext for wrapping sockets.

Python 2.7.9 was released three years ago, so I'm inclined to drop support for 2.7.8, but I'm not dead-set on it.