### PR TITLE
Signal WSGI app that the input is terminated

### DIFF
--- a/cheroot/wsgi.py
+++ b/cheroot/wsgi.py
@@ -249,6 +249,7 @@ class Gateway_10(Gateway):
             'SERVER_SOFTWARE': req.server.software,
             'wsgi.errors': sys.stderr,
             'wsgi.input': req.rfile,
+            'wsgi.input_terminated': bool(req.chunked_read),
             'wsgi.multiprocess': False,
             'wsgi.multithread': True,
             'wsgi.run_once': False,


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
  * Feature


* **What is the related issue number (starting with `#`)**
  * cherrypy/cherrypy#1664
  * Pylons/webob#278
  * unbit/uwsgi#1428


* **What is the current behavior?** (You can also link to an open issue here)
``'wsgi.input_terminated'`` WSGI env var is not set.


* **What is the new behavior (if this is a feature change)?**
``'wsgi.input_terminated'`` WSGI env var is set if the Transfer-Encoding is chunked.


* **Other information**:
This PR sets ``env['wsgi.input_terminated'] = True`` if the request uses
chunked Transfer-Encoding, so that WSGI app would know that it's safe
to read from ``env['wsgi.input']`` stream.

It implements @mitsuhiko's proposal:
https://gist.github.com/mitsuhiko/5721547

///
@davidism and @jaraco please review.