### PR TITLE
Ensure response headers are being sent before closing the response

### DIFF
--- a/cheroot/server.py
+++ b/cheroot/server.py
@@ -973,9 +973,6 @@ class HTTPRequest(object):
 
         self.server.gateway(self).respond()
 
-        if (self.ready and not self.sent_headers):
-            self.sent_headers = True
-            self.send_headers()
         if self.chunked_write:
             self.conn.wfile.write(b'0\r\n\r\n')
 
@@ -1015,6 +1012,11 @@ class HTTPRequest(object):
         except socket.error as ex:
             if ex.args[0] not in errors.socket_errors_to_ignore:
                 raise
+
+    def write_headers(self):
+        """Write headers to the client if not already sent."""
+        self.sent_headers = True
+        self.send_headers()
 
     def write(self, chunk):
         """Write unbuffered data to the client."""

--- a/cheroot/server.py
+++ b/cheroot/server.py
@@ -972,7 +972,7 @@ class HTTPRequest(object):
             self.rfile = KnownLengthRFile(self.conn.rfile, cl)
 
         self.server.gateway(self).respond()
-        self.ensure_headers_sent()
+        self.ready and self.ensure_headers_sent()
 
         if self.chunked_write:
             self.conn.wfile.write(b'0\r\n\r\n')

--- a/cheroot/server.py
+++ b/cheroot/server.py
@@ -972,6 +972,7 @@ class HTTPRequest(object):
             self.rfile = KnownLengthRFile(self.conn.rfile, cl)
 
         self.server.gateway(self).respond()
+        self.ensure_headers_sent()
 
         if self.chunked_write:
             self.conn.wfile.write(b'0\r\n\r\n')
@@ -1013,10 +1014,11 @@ class HTTPRequest(object):
             if ex.args[0] not in errors.socket_errors_to_ignore:
                 raise
 
-    def write_headers(self):
-        """Write headers to the client if not already sent."""
-        self.sent_headers = True
-        self.send_headers()
+    def ensure_headers_sent(self):
+        """Ensure headers are sent to the client if not already sent."""
+        if not self.sent_headers:
+            self.sent_headers = True
+            self.send_headers()
 
     def write(self, chunk):
         """Write unbuffered data to the client."""

--- a/cheroot/test/test_core.py
+++ b/cheroot/test/test_core.py
@@ -351,3 +351,56 @@ def test_garbage_in(test_client):
         # "Connection reset by peer" is also acceptable.
         if ex.errno != errno.ECONNRESET:
             raise
+
+
+class CloseController(object):
+    """Controller for testing the close callback."""
+
+    def __init__(self):
+        """Sets the default values."""
+        self.sent_headers_before_closing = None
+        self.req = None
+
+    def __call__(self, environ, start_response):
+        """Gets the req to know header sent status."""
+        self.req = start_response.__self__.req
+        resp = CloseResponse(self.close)
+        start_response(resp.status, resp.headers.items())
+        return resp
+
+    def close(self):
+        """Hook for close, tests if headers already sent."""
+        self.sent_headers_before_closing = \
+            self.req is not None and self.req.sent_headers
+
+
+class CloseResponse(object):
+    """Dummy empty response to trigger the no body status."""
+    def __init__(self, close):
+        """Use some defaults to ensure we have a header."""
+        self.status = '200 OK'
+        self.headers = {'Content-Type': 'text/html'}
+        self.close = close
+
+    def __getitem__(self, index):
+        """Ensures we don't have a body."""
+        raise IndexError()
+
+    def output(self):
+        """Returns self to hook the close method."""
+        return self
+
+
+@pytest.fixture
+def testing_server_close(wsgi_server_client):
+    wsgi_server = wsgi_server_client.server_instance
+    wsgi_server.wsgi_app = CloseController()
+    wsgi_server.max_request_body_size = 30000000
+    wsgi_server.server_client = wsgi_server_client
+    return wsgi_server
+
+
+def test_send_header_before_closing(testing_server_close):
+    """Tests we are actually sending the headers before closing the response."""
+    testing_server_close.server_client.get('/')
+    assert testing_server_close.wsgi_app.sent_headers_before_closing is True

--- a/cheroot/test/test_core.py
+++ b/cheroot/test/test_core.py
@@ -357,12 +357,12 @@ class CloseController(object):
     """Controller for testing the close callback."""
 
     def __init__(self):
-        """Sets the default values."""
+        """Set the default values."""
         self.sent_headers_before_closing = None
         self.req = None
 
     def __call__(self, environ, start_response):
-        """Gets the req to know header sent status."""
+        """Get the req to know header sent status."""
         self.req = start_response.__self__.req
         resp = CloseResponse(self.close)
         start_response(resp.status, resp.headers.items())
@@ -376,6 +376,7 @@ class CloseController(object):
 
 class CloseResponse(object):
     """Dummy empty response to trigger the no body status."""
+
     def __init__(self, close):
         """Use some defaults to ensure we have a header."""
         self.status = '200 OK'
@@ -383,16 +384,17 @@ class CloseResponse(object):
         self.close = close
 
     def __getitem__(self, index):
-        """Ensures we don't have a body."""
+        """Ensure we don't have a body."""
         raise IndexError()
 
     def output(self):
-        """Returns self to hook the close method."""
+        """Return self to hook the close method."""
         return self
 
 
 @pytest.fixture
 def testing_server_close(wsgi_server_client):
+    """Attach a WSGI app to the given server and pre-configure it."""
     wsgi_server = wsgi_server_client.server_instance
     wsgi_server.wsgi_app = CloseController()
     wsgi_server.max_request_body_size = 30000000
@@ -401,6 +403,6 @@ def testing_server_close(wsgi_server_client):
 
 
 def test_send_header_before_closing(testing_server_close):
-    """Tests we are actually sending the headers before closing the response."""
+    """Test we are actually sending the headers before closing the response."""
     testing_server_close.server_client.get('/')
     assert testing_server_close.wsgi_app.sent_headers_before_closing is True

--- a/cheroot/test/test_core.py
+++ b/cheroot/test/test_core.py
@@ -365,7 +365,7 @@ class CloseController(object):
 
     def close(self):
         """Hook for close, write hello."""
-        self.req.write('hello'.encode('utf-8'))
+        self.req.write(b'hello')
 
 
 class CloseResponse(object):
@@ -399,4 +399,4 @@ def testing_server_close(wsgi_server_client):
 def test_send_header_before_closing(testing_server_close):
     """Test we are actually sending the headers before calling 'close'."""
     _, _, resp_body = testing_server_close.server_client.get('/')
-    assert resp_body == 'hello'.encode('utf-8')
+    assert resp_body == b'hello'

--- a/cheroot/test/test_core.py
+++ b/cheroot/test/test_core.py
@@ -356,11 +356,6 @@ def test_garbage_in(test_client):
 class CloseController(object):
     """Controller for testing the close callback."""
 
-    def __init__(self):
-        """Set the default values."""
-        self.sent_headers_before_closing = None
-        self.req = None
-
     def __call__(self, environ, start_response):
         """Get the req to know header sent status."""
         self.req = start_response.__self__.req
@@ -369,9 +364,8 @@ class CloseController(object):
         return resp
 
     def close(self):
-        """Hook for close, tests if headers already sent."""
-        self.sent_headers_before_closing = \
-            self.req is not None and self.req.sent_headers
+        """Hook for close, write hello."""
+        self.req.write('hello'.encode('utf-8'))
 
 
 class CloseResponse(object):
@@ -403,6 +397,6 @@ def testing_server_close(wsgi_server_client):
 
 
 def test_send_header_before_closing(testing_server_close):
-    """Test we are actually sending the headers before closing the response."""
-    testing_server_close.server_client.get('/')
-    assert testing_server_close.wsgi_app.sent_headers_before_closing is True
+    """Test we are actually sending the headers before calling 'close'."""
+    _, _, resp_body = testing_server_close.server_client.get('/')
+    assert resp_body == 'hello'.encode('utf-8')

--- a/cheroot/wsgi.py
+++ b/cheroot/wsgi.py
@@ -137,6 +137,9 @@ class Gateway(server.Gateway):
                     raise ValueError('WSGI Applications must yield bytes')
                 self.write(chunk)
         finally:
+            # Send headers if not already sent
+            if not self.req.sent_headers:
+                self.req.write_headers()
             if hasattr(response, 'close'):
                 response.close()
 
@@ -213,8 +216,7 @@ class Gateway(server.Gateway):
                 chunk = chunk[:rbo]
 
         if not self.req.sent_headers:
-            self.req.sent_headers = True
-            self.req.send_headers()
+            self.req.write_headers()
 
         self.req.write(chunk)
 

--- a/cheroot/wsgi.py
+++ b/cheroot/wsgi.py
@@ -138,8 +138,7 @@ class Gateway(server.Gateway):
                 self.write(chunk)
         finally:
             # Send headers if not already sent
-            if not self.req.sent_headers:
-                self.req.write_headers()
+            self.req.ensure_headers_sent()
             if hasattr(response, 'close'):
                 response.close()
 
@@ -215,8 +214,7 @@ class Gateway(server.Gateway):
                 # to fit (so the client doesn't hang) and raise an error later.
                 chunk = chunk[:rbo]
 
-        if not self.req.sent_headers:
-            self.req.write_headers()
+        self.req.ensure_headers_sent()
 
         self.req.write(chunk)
 


### PR DESCRIPTION

Fixes https://github.com/cherrypy/cherrypy/issues/1404

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bugfix

* **What is the related issue number (starting with `#`)**

https://github.com/cherrypy/cherrypy/issues/1404

* **What is the current behavior?** (You can also link to an open issue here)

on_end_request hook is being call **before** sending a response on cherrypy

* **What is the new behavior (if this is a feature change)?**

on_end_request hook is being call **after** sending a response on cherrypy

* **Other information**:

I found https://github.com/Lawouach/WebSocket-for-Python/issues/158 which lead me to this "PR" https://bitbucket.org/cherrypy/cherrypy/pull-requests/121/fixing-issue-1404-on_end_request-hook-is/diff 
I ported that to cheroot and addressed the last comment from  "Sylvain Hellegouarch"
