### PR TITLE
Actually use 'reponse' in _conditional_error() method

### DIFF
--- a/cheroot/server.py
+++ b/cheroot/server.py
@@ -1202,7 +1202,7 @@ class HTTPConnection(object):
             return
 
         try:
-            req.simple_response('408 Request Timeout')
+            req.simple_response(response)
         except errors.FatalSSLAlert:
             pass
         except errors.NoSSLError:


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix

* **What is the related issue number (starting with `#`)**
N/A

* **What is the current behavior?** (You can also link to an open issue here)
Bug was introduced during this refactoring:
  https://github.com/cherrypy/cheroot/commit/a00ad088e75940729a279ebfac9d857012a712fb

The response parameter is never used, instead the hardcoded string '408 Request Timeout' is always sent.

* **What is the new behavior (if this is a feature change)?**

Sends 'response' instead

* **Other information**:
