### PR TITLE
add py3 compatibility to wsgi docstring example

### DIFF
--- a/cheroot/wsgi.py
+++ b/cheroot/wsgi.py
@@ -8,7 +8,7 @@ Simplest example on how to use this server::
         status = '200 OK'
         response_headers = [('Content-type','text/plain')]
         start_response(status, response_headers)
-        return ['Hello world!']
+        return [b'Hello world!']
 
     addr = '0.0.0.0', 8070
     server = wsgi.Server(addr, my_crazy_app)


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix


* **What is the related issue number (starting with `#`)**
fixes #77 

* **What is the current behavior?** (You can also link to an open issue here)
A WSGI application iterable is supposed to return byte strings for response body. If it returns Unicode strings it is an error.

A WSGI server is not meant to convert Unicode strings to byte strings automatically.

The example Hello World server in the wsgi.py docstring fails with a `ValueError: WSGI Applications must yield bytes` in Python 3. This is because in Python 3, all strings are unicode by default.  

This behavior can be disappointing and confusing for newcomers testing out cheroot.

* **What is the new behavior (if this is a feature change)?**
Return bytes instead of unicode. I added a "b" ! :)

* **Other information**:
Cheers!