### PR TITLE
Support AF_UNIX in server.HTTPServer.bind_addr

### DIFF
--- a/cheroot/server.py
+++ b/cheroot/server.py
@@ -1607,11 +1607,15 @@ class HTTPServer(object):
                 pass
 
         self.socket.bind(self.bind_addr)
-        # TODO: keep separate
-        if family == socket.AF_UNIX:
-            self.bind_addr = self.socket.getsockname()
-        else:
-            self.bind_addr = self.socket.getsockname()[:2]
+        # TODO: keep requested bind_addr separate real bound_addr (port is
+        # different in case of ephemeral port 0)
+        self.bind_addr = self.socket.getsockname()
+        if family != socket.AF_UNIX:
+            """UNIX domain sockets are strings or bytes.
+
+            In case of bytes with a leading null-byte it's an abstract socket.
+            """
+            self.bind_addr = self.bind_addr[:2]
 
     def tick(self):
         """Accept a new connection and put it on the Queue."""

--- a/cheroot/server.py
+++ b/cheroot/server.py
@@ -1607,7 +1607,11 @@ class HTTPServer(object):
                 pass
 
         self.socket.bind(self.bind_addr)
-        self.bind_addr = self.socket.getsockname()[:2]  # TODO: keep separate
+        # TODO: keep separate
+        if family == socket.AF_UNIX:
+            self.bind_addr = self.socket.getsockname()
+        else:
+            self.bind_addr = self.socket.getsockname()[:2]
 
     def tick(self):
         """Accept a new connection and put it on the Queue."""

--- a/cheroot/test/test_server.py
+++ b/cheroot/test/test_server.py
@@ -1,0 +1,96 @@
+"""Tests for the HTTP server."""
+# -*- coding: utf-8 -*-
+# vim: set fileencoding=utf-8 :
+
+import os
+import tempfile
+import threading
+import time
+
+import pytest
+
+import cheroot.server
+
+from cheroot.testing import (
+    ANY_INTERFACE_IPV4,
+    ANY_INTERFACE_IPV6,
+    EPHEMERAL_PORT,
+)
+
+
+def make_http_server(bind_addr):
+    """Create and start an HTTP server bound to bind_addr."""
+    httpserver = cheroot.server.HTTPServer(
+        bind_addr=bind_addr,
+        gateway=cheroot.server.Gateway,
+    )
+
+    threading.Thread(target=httpserver.safe_start).start()
+
+    while not httpserver.ready:
+        time.sleep(0.1)
+
+    return httpserver
+
+
+@pytest.fixture
+def http_server():
+    """Provision a server creator as a fixture."""
+    def start_srv():
+        bind_addr = yield
+        httpserver = make_http_server(bind_addr)
+        yield httpserver
+        yield httpserver
+
+    srv_creator = iter(start_srv())
+    next(srv_creator)
+    yield srv_creator
+    try:
+        while True:
+            httpserver = next(srv_creator)
+            if httpserver is not None:
+                httpserver.stop()
+    except StopIteration:
+        pass
+
+
+@pytest.fixture
+def unix_sock_file():
+    """Check that bound UNIX socket address is stored in server."""
+    tmp_sock_fh, tmp_sock_fname = tempfile.mkstemp()
+
+    yield tmp_sock_fname
+
+    os.close(tmp_sock_fh)
+    os.unlink(tmp_sock_fname)
+
+
+@pytest.mark.parametrize(
+    'ip_addr',
+    (
+        ANY_INTERFACE_IPV4,
+        ANY_INTERFACE_IPV6,
+    )
+)
+def test_bind_addr_inet(http_server, ip_addr):
+    """Check that bound IP address is stored in server."""
+    httpserver = http_server.send((ip_addr, EPHEMERAL_PORT))
+
+    assert httpserver.bind_addr[0] == ip_addr
+    assert httpserver.bind_addr[1] != EPHEMERAL_PORT
+
+
+def test_bind_addr_unix(http_server, unix_sock_file):
+    """Check that bound UNIX socket address is stored in server."""
+    httpserver = http_server.send(unix_sock_file)
+
+    assert httpserver.bind_addr == unix_sock_file
+
+
+@pytest.mark.skip  # FIXME: investigate binding to abstract sockets issue
+def test_bind_addr_unix_abstract(http_server):
+    """Check that bound UNIX socket address is stored in server."""
+    unix_abstract_sock = b'\x00cheroot/test/socket/here.sock'
+    httpserver = http_server.send(unix_abstract_sock)
+
+    assert httpserver.bind_addr == unix_abstract_sock


### PR DESCRIPTION
[This hotfix](https://github.com/cherrypy/cheroot/commit/81abec023851cc9f60443ec3b4d815e83fe9c39d) breaks AF_UNIX binding by leaving only the first two characters of the socket path in bind_addr (as getsockname [returns the socket file path in AF_UNIX](https://docs.python.org/3/library/socket.html#socket-families)). I caught this as my code then goes on to chmod bind_addr expecting it to be a correct path after binding.

This is imo a more urgent fix than the TODO of refactoring out the hack as the hack renders valid usecases broken in 6.1.0 without monkeypatching or equivalent.