### PR TITLE
Fix check for windows OS in cheroot.server

### DIFF
--- a/cheroot/server.py
+++ b/cheroot/server.py
@@ -1719,7 +1719,7 @@ class HTTPServer(object):
         """Create (or recreate) the actual socket object."""
         self.socket = socket.socket(family, type, proto)
         prevent_socket_inheritance(self.socket)
-        if IS_WINDOWS:
+        if not IS_WINDOWS:
             # Windows has different semantics for SO_REUSEADDR,
             # so don't set it.
             # https://msdn.microsoft.com/en-us/library/ms740621(v=vs.85).aspx


### PR DESCRIPTION
Check was inverted in:
```
commit 31806a8d138586f888c6085511e66513767bca69
Author: Sviatoslav Sydorenko <xx@xxxxxxxxx.xxx.xx>
Date:   Sun Apr 8 20:44:16 2018 +0200

    Optimize check for windows OS in cheroot.server
```
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix

* **What is the related issue number (starting with `#`)**
No issue filed


* **What is the current behavior?** (You can also link to an open issue here)
CherryPy tests and servers started failing on v6.2.0 with 'address already in use'
when restarted. Bisected the issue and found the fairly obvious error in 31806a8d


* **What is the new behavior (if this is a feature change)?**
Fixes bug
