### PR TITLE
exclude legacy dependencies when using python3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ params = dict(
     ),
     python_requires='>=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*',
     install_requires=[
-        'backports.functools_lru_cache',
+        'backports.functools_lru_cache;python_version<"3"',
         'six>=1.11.0',
         'more_itertools>=2.6',
     ],
@@ -72,7 +72,7 @@ params = dict(
             'codecov',
 
             'pytest-cov',
-            'backports.unittest_mock',
+            'backports.unittest_mock;python_version<"3"',
         ],
     },
     setup_requires=[


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Fix Python 3 compatibility


* **What is the related issue number (starting with `#`)**

I have not opened an issue for this and went straight ahead to fix it.

However, this was reported in the Arch Linux bugtracker as:
https://bugs.archlinux.org/task/58204


* **What is the current behavior?** (You can also link to an open issue here)

Currently the setup.py has some dependencies that are incompatible with
Python 3.
Both functools_lru_cache and unittest_mock are embedded in Python 3 by default.
Requiring these backports when using python3 will fail and render the build
unusable.


* **What is the new behavior (if this is a feature change)?**

Setuptools provides a nice way to deal with this by using the proper
annotations for the dependencies.
This PR introduces said annotations for dependencies that are incompatible
with Python 3.


* **Other information**:

