### PR TITLE
cheroot.server: procedure ``serve()`` has  detached from ``start()``

### DIFF
--- a/cheroot/server.py
+++ b/cheroot/server.py
@@ -1704,7 +1704,7 @@ class HTTPServer:
     def start(self):
         """Run the server forever."""
         # We don't have to trap KeyboardInterrupt or SystemExit here,
-        # because cherrpy.server already does so, calling self.stop() for us.
+        # because cherrypy.server already does so, calling self.stop() for us.
         # If you're using this server with another framework, you should
         # trap those exceptions in whatever code block calls start().
         self.prepare()

--- a/cheroot/server.py
+++ b/cheroot/server.py
@@ -39,6 +39,21 @@ number of requests and their responses, so we run a nested loop::
                 if req.close_connection:
                     return
 
+For running a server you can invoke :func:`start() <HTTPServer.start()>` (it
+will run the server forever) or use invoking :func:`prepare()
+<HTTPServer.prepare()>` and :func:`serve() <HTTPServer.serve()>` like this::
+
+    server = HTTPServer(...)
+    server.prepare()
+    try:
+        threading.Thread(target=server.serve).start()
+
+        # waiting/detecting some appropriate stop condition here
+        ...
+
+    finally:
+        server.stop()
+
 And now for a trivial doctest to exercise the test suite
 
 >>> 'HTTPServer' in globals()
@@ -1609,7 +1624,7 @@ class HTTPServer:
     def prepare(self):
         """Prepare server to serving requests.
 
-        It binds a socket's port, setups the socket to listen() and does
+        It binds a socket's port, setups the socket to ``listen()`` and does
         other preparing things.
         """
         self._interrupt = None
@@ -1685,7 +1700,7 @@ class HTTPServer:
         self._start_time = time.time()
 
     def serve(self):
-        """Serve requests, after invoking prepare()."""
+        """Serve requests, after invoking :func:`prepare()`."""
         while self.ready:
             try:
                 self.tick()
@@ -1703,7 +1718,10 @@ class HTTPServer:
                     raise self.interrupt
 
     def start(self):
-        """Run the server forever."""
+        """Run the server forever.
+
+        It is shortcut for invoking :func:`prepare()` then :func:`serve()`.
+        """
         # We don't have to trap KeyboardInterrupt or SystemExit here,
         # because cherrypy.server already does so, calling self.stop() for us.
         # If you're using this server with another framework, you should

--- a/cheroot/server.py
+++ b/cheroot/server.py
@@ -1606,12 +1606,11 @@ class HTTPServer:
             self.stop()
             raise
 
-    def start(self):
-        """Run the server forever."""
-        # We don't have to trap KeyboardInterrupt or SystemExit here,
-        # because cherrpy.server already does so, calling self.stop() for us.
-        # If you're using this server with another framework, you should
-        # trap those exceptions in whatever code block calls start().
+    def prepare(self):
+        """Prepare server to serving requests.
+
+        It binds a socket's port, setups the socket to listen() and does
+        other preparing things."""
         self._interrupt = None
 
         if self.software is None:
@@ -1683,6 +1682,9 @@ class HTTPServer:
 
         self.ready = True
         self._start_time = time.time()
+
+    def serve(self):
+        """Serve requests, after invoking prepare()."""
         while self.ready:
             try:
                 self.tick()
@@ -1698,6 +1700,15 @@ class HTTPServer:
                     time.sleep(0.1)
                 if self.interrupt:
                     raise self.interrupt
+
+    def start(self):
+        """Run the server forever."""
+        # We don't have to trap KeyboardInterrupt or SystemExit here,
+        # because cherrpy.server already does so, calling self.stop() for us.
+        # If you're using this server with another framework, you should
+        # trap those exceptions in whatever code block calls start().
+        self.prepare()
+        self.serve()
 
     def error_log(self, msg='', level=20, traceback=False):
         """Write error message to log.

--- a/cheroot/server.py
+++ b/cheroot/server.py
@@ -7,12 +7,12 @@ sticking incoming connections onto a Queue::
 
     server = HTTPServer(...)
     server.start()
-    while True:
-        tick()
-        # This blocks until a request comes in:
-        child = socket.accept()
-        conn = HTTPConnection(child, ...)
-        server.requests.put(conn)
+    ->  while True:
+            tick()
+            # This blocks until a request comes in:
+            child = socket.accept()
+            conn = HTTPConnection(child, ...)
+            server.requests.put(conn)
 
 Worker threads are kept in a pool and poll the Queue, popping off and then
 handling each connection in turn. Each connection can consist of an arbitrary

--- a/cheroot/server.py
+++ b/cheroot/server.py
@@ -1610,7 +1610,8 @@ class HTTPServer:
         """Prepare server to serving requests.
 
         It binds a socket's port, setups the socket to listen() and does
-        other preparing things."""
+        other preparing things.
+        """
         self._interrupt = None
 
         if self.software is None:


### PR DESCRIPTION
* **What is the related issue number (starting with `#`)**

it is release with issues #68 ("is there any right way to interrupt a started server?")


* **What is the current behavior?** (You can also link to an open issue here)

see my next simple example:

```python
# -*- mode: python; coding: utf-8 -*-

from cheroot.wsgi import Server
import signal
import threading

def helloAAA_wsgi(environ, start_response):
    start_response('200 OK', [('Content-type','text/plain;charset=utf-8')])
    
    yield 'Hello world! #AAA\n'.encode()

def helloBBB_wsgi(environ, start_response):
    start_response('200 OK', [('Content-type','text/plain;charset=utf-8')])
    
    yield 'Hello world! #BBB\n'.encode()

def helloCCC_wsgi(environ, start_response):
    start_response('200 OK', [('Content-type','text/plain;charset=utf-8')])
    
    yield 'Hello world! #CCC\n'.encode()

def main():
    signal.pthread_sigmask(signal.SIG_BLOCK, {signal.SIGINT, signal.SIGTERM})
    
    serverAAA = Server(('127.0.0.1', 8081), helloAAA_wsgi)
    serverBBB = Server(('127.0.0.1', 8082), helloBBB_wsgi)
    serverCCC = Server(('127.0.0.1', 8083), helloCCC_wsgi)
    
    t1 = threading.Thread(target=serverAAA.start) # THERE IS AN ERROR
    t2 = threading.Thread(target=serverBBB.start) # THERE IS AN ERROR
    t3 = threading.Thread(target=serverCCC.start) # THERE IS AN ERROR
    
    t1.start()
    t2.start()
    t3.start()
    
    print('*** all servers have started! *** (we are lying here right now :))')
    
    # XXX   IT IS WRONG!
    #       we can't really say about finishing start-procedure.
    #       and we can't be sure about ability to invoke ``stop()`` (see below).
    #       if ``start()`` hadn't done ready status yet, we couldn't invoke ``stop()``
    
    print('*** serving requests is in process... ***')
    
    signal.sigwaitinfo({signal.SIGINT, signal.SIGTERM})
    
    print('*** terminating... ***')
    
    serverAAA.stop()
    serverBBB.stop()
    serverCCC.stop()
    
    t1.join()
    t2.join()
    t3.join()
    
    # XXX
    #       we won't be here, if any ``stop()`` has invoked too early
    
    print('*** gracefully terminated! ***')

if __name__ == '__main__':
    main()
```


* **What is the new behavior (if this is a feature change)?**

please, see my next another example:

```python
# -*- mode: python; coding: utf-8 -*-

from cheroot.wsgi import Server
import signal
import threading

def helloAAA_wsgi(environ, start_response):
    start_response('200 OK', [('Content-type','text/plain;charset=utf-8')])
    
    yield 'Hello world! #AAA\n'.encode()

def helloBBB_wsgi(environ, start_response):
    start_response('200 OK', [('Content-type','text/plain;charset=utf-8')])
    
    yield 'Hello world! #BBB\n'.encode()

def helloCCC_wsgi(environ, start_response):
    start_response('200 OK', [('Content-type','text/plain;charset=utf-8')])
    
    yield 'Hello world! #CCC\n'.encode()

def main():
    signal.pthread_sigmask(signal.SIG_BLOCK, {signal.SIGINT, signal.SIGTERM})
    
    serverAAA = Server(('127.0.0.1', 8081), helloAAA_wsgi)
    serverBBB = Server(('127.0.0.1', 8082), helloBBB_wsgi)
    serverCCC = Server(('127.0.0.1', 8083), helloCCC_wsgi)
    
    serverAAA.start(dont_serve=True)
    serverBBB.start(dont_serve=True)
    serverCCC.start(dont_serve=True)
    
    print('*** all servers have started! ***')
    
    t1 = threading.Thread(target=serverAAA.serve)
    t2 = threading.Thread(target=serverBBB.serve)
    t3 = threading.Thread(target=serverCCC.serve)
    
    t1.start()
    t2.start()
    t3.start()
    
    print('*** serving requests is in process... ***')
    
    signal.sigwaitinfo({signal.SIGINT, signal.SIGTERM})
    
    print('*** terminating... ***')
    
    # now it is SAFE to invoke ``stop()`` here
    
    serverAAA.stop()
    serverBBB.stop()
    serverCCC.stop()
    
    t1.join()
    t2.join()
    t3.join()
    
    print('*** gracefully terminated! ***')

if __name__ == '__main__':
    main()
```

* **Other information**:


* **Checklist**:

  - [X] I think the code is well written
  - [ ] I wrote [good commit messages][1]
  - [X] I have [squashed related commits together][2] after the changes have been approved
  - [X] Unit tests for the changes exist
  - [ ] Integration tests for the changes exist (if applicable)
  - [X] I used the same coding conventions as the rest of the project
  - [X] The new code doesn't generate linter offenses
  - [X] Documentation reflects the changes
  - [ ] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences

[1]: http://chris.beams.io/posts/git-commit/
[2]: https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cherrypy/cheroot/98)
<!-- Reviewable:end -->
