### PR TITLE
Fix #100 Non-int content-length header

### DIFF
--- a/cheroot/server.py
+++ b/cheroot/server.py
@@ -915,7 +915,9 @@ class HTTPRequest:
         try:
             cl = int(self.inheaders.get(b'Content-Length', 0))
         except ValueError:
-            self.simple_response('400 Bad Request', 'Malformed Content-Length Header.')
+            self.simple_response(
+                '400 Bad Request',
+                'Malformed Content-Length Header.')
             return False
 
         if mrbs and cl > mrbs:

--- a/cheroot/server.py
+++ b/cheroot/server.py
@@ -911,7 +911,14 @@ class HTTPRequest:
             return False
 
         mrbs = self.server.max_request_body_size
-        if mrbs and int(self.inheaders.get(b'Content-Length', 0)) > mrbs:
+
+        try:
+            cl = int(self.inheaders.get(b'Content-Length', 0))
+        except ValueError:
+            self.simple_response('400 Bad Request', 'Malformed Content-Length Header.')
+            return False
+
+        if mrbs and cl > mrbs:
             self.simple_response(
                 '413 Request Entity Too Large',
                 'The entity sent with the request exceeds the maximum '

--- a/cheroot/test/test_conn.py
+++ b/cheroot/test/test_conn.py
@@ -817,7 +817,7 @@ def test_Content_Length_Non_Int(test_client):
     actual_status = int(status_line[:3])
 
     assert actual_status == 400
-    assert actual_resp_body == 'Malformed Content-Length Header.'
+    assert actual_resp_body == b'Malformed Content-Length Header.'
 
     conn.close()
 

--- a/cheroot/test/test_conn.py
+++ b/cheroot/test/test_conn.py
@@ -800,10 +800,8 @@ def test_Content_Length_in(test_client):
     conn.close()
 
 
-def test_Content_Length_Non_Int(test_client):
-    """ Try a request where Content-Length header is non-compatible
-    """
-
+def test_Content_Length_not_int(test_client):
+    """Test that malicious Content-Length header returns 400."""
     status_line, actual_headers, actual_resp_body = test_client.post(
         '/upload',
         headers=[

--- a/cheroot/test/test_conn.py
+++ b/cheroot/test/test_conn.py
@@ -804,22 +804,17 @@ def test_Content_Length_Non_Int(test_client):
     """ Try a request where Content-Length header is non-compatible
     """
 
-    conn = test_client.get_connection()
-
-    conn.putrequest('POST', '/upload', skip_host=True)
-    conn.putheader('Host', conn.host)
-    conn.putheader('Content-Type', 'text/plain')
-    conn.putheader('Content-Length', 'not-an-integer')
-    conn.endheaders()
-
-    response = conn.getresponse()
-    status_line, actual_headers, actual_resp_body = webtest.shb(response)
+    status_line, actual_headers, actual_resp_body = test_client.post(
+        '/upload',
+        headers=[
+            ('Content-Type', 'text/plain'),
+            ('Content-Length', 'not-an-integer'),
+        ],
+    )
     actual_status = int(status_line[:3])
 
     assert actual_status == 400
     assert actual_resp_body == b'Malformed Content-Length Header.'
-
-    conn.close()
 
 
 @pytest.mark.parametrize(

--- a/cheroot/test/test_conn.py
+++ b/cheroot/test/test_conn.py
@@ -800,6 +800,28 @@ def test_Content_Length_in(test_client):
     conn.close()
 
 
+def test_Content_Length_Non_Int(test_client):
+    """ Try a request where Content-Length header is non-compatible
+    """
+
+    conn = test_client.get_connection()
+
+    conn.putrequest('POST', '/upload', skip_host=True)
+    conn.putheader('Host', conn.host)
+    conn.putheader('Content-Type', 'text/plain')
+    conn.putheader('Content-Length', 'not-an-integer')
+    conn.endheaders()
+
+    response = conn.getresponse()
+    status_line, actual_headers, actual_resp_body = webtest.shb(response)
+    actual_status = int(status_line[:3])
+
+    assert actual_status == 400
+    assert actual_resp_body == 'Malformed Content-Length Header.'
+
+    conn.close()
+
+
 @pytest.mark.parametrize(
     'uri,expected_resp_status,expected_resp_body',
     (


### PR DESCRIPTION
Use try/except to catch ValueError when converting content-length to int. Responds to client with 400 error rather than 500 error.

* **What kind of change does this PR introduce?**
  - [X] bug fix
  - [ ] feature
  - [ ] docs update
  - [ ] tests/coverage improvement
  - [ ] refactoring
  - [ ] other



* **What is the related issue number (starting with `#`)**
Fixes #100


* **What is the current behavior?** (You can also link to an open issue here)
Server returns ambiguous 500 error to client when Content-Length header is not an int or able to be converted to int.


* **What is the new behavior (if this is a feature change)?**
Server returns 400 error to client with message "Malformed Content-Length Header."


* **Other information**:
I'm not 100% sure if there is a better 4XX response, but 400 is appropriate.

* **Checklist**:

  - [X] I think the code is well written
  - [X] I wrote [good commit messages][1]
  - [X] I have [squashed related commits together][2] after the changes have been approved
  - [X] Unit tests for the changes exist
  - [X] Integration tests for the changes exist (if applicable)
  - [X] I used the same coding conventions as the rest of the project
  - [X] The new code doesn't generate linter offenses
  - [X] Documentation reflects the changes
  - [X] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences

[1]: http://chris.beams.io/posts/git-commit/
[2]: https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cherrypy/cheroot/101)
<!-- Reviewable:end -->
