### PR TITLE
Add some framework for SSL tests and refactor makefile a bit

### DIFF
--- a/cheroot/makefile.py
+++ b/cheroot/makefile.py
@@ -51,6 +51,16 @@ class MakeFile_PY2(getattr(socket, '_fileobject', object)):
         self.bytes_read = 0
         self.bytes_written = 0
         socket._fileobject.__init__(self, *args, **kwargs)
+        self._refcount = 0
+
+    def _reuse(self):
+        self._refcount += 1
+
+    def _drop(self):
+        if self._refcount < 0:
+            self.close()
+        else:
+            self._refcount -= 1
 
     def write(self, data):
         """Sendall for non-blocking sockets."""

--- a/cheroot/server.py
+++ b/cheroot/server.py
@@ -87,7 +87,7 @@ from six.moves import urllib
 from . import errors, __version__
 from ._compat import bton, ntou
 from .workers import threadpool
-from .makefile import MakeFile
+from .makefile import MakeFile, StreamWriter
 
 
 __all__ = ('HTTPRequest', 'HTTPConnection', 'HTTPServer',
@@ -1261,7 +1261,7 @@ class HTTPConnection:
         if not req or req.sent_headers:
             return
         # Unwrap wfile
-        self.wfile = MakeFile(self.socket._sock, 'wb', self.wbufsize)
+        self.wfile = StreamWriter(self.socket._sock, 'wb', self.wbufsize)
         msg = (
             'The client sent a plain HTTP request, but '
             'this server only speaks HTTPS on this port.'

--- a/cheroot/ssl/builtin.py
+++ b/cheroot/ssl/builtin.py
@@ -27,8 +27,7 @@ import six
 
 from . import Adapter
 from .. import errors
-from ..makefile import MakeFile
-
+from ..makefile import StreamReader, StreamWriter
 
 if six.PY3:
     generic_socket_error = OSError
@@ -200,4 +199,5 @@ class BuiltinSSLAdapter(Adapter):
 
     def makefile(self, sock, mode='r', bufsize=DEFAULT_BUFFER_SIZE):
         """Return socket file object."""
-        return MakeFile(sock, mode, bufsize)
+        cls = StreamReader if 'r' in mode else StreamWriter
+        return cls(sock, mode, bufsize)

--- a/cheroot/ssl/pyopenssl.py
+++ b/cheroot/ssl/pyopenssl.py
@@ -155,6 +155,10 @@ class SSLConnectionProxyMeta:
             'shutdown',
         )
 
+        proxy_props = (
+            'family',
+        )
+
         def lock_decorator(method):
             """Create a proxy method for a new class."""
             def proxy_wrapper(self, *args):
@@ -170,6 +174,15 @@ class SSLConnectionProxyMeta:
         for m in proxy_methods:
             nmspc[m] = lock_decorator(m)
             nmspc[m].__name__ = m
+
+        def make_property(property_):
+            """Create a proxy method for a new class."""
+            def proxy_prop_wrapper(self):
+                return getattr(self._ssl_conn, property_)
+            proxy_prop_wrapper.__name__ = property_
+            return property(proxy_prop_wrapper)
+        for p in proxy_props:
+            nmspc[p] = make_property(p)
 
         # Doesn't work via super() for some reason.
         # Falling back to type() instead:

--- a/cheroot/ssl/pyopenssl.py
+++ b/cheroot/ssl/pyopenssl.py
@@ -38,6 +38,8 @@ import socket
 import threading
 import time
 
+import six
+
 try:
     from OpenSSL import SSL
     from OpenSSL import crypto
@@ -133,6 +135,48 @@ class SSLFileobjectStreamWriter(SSLFileobjectMixin, StreamWriter):
     """SSL file object attached to a socket object."""
 
 
+class SSLConnectionProxyMeta:
+    """Metaclass for generating a bunch of proxy methods."""
+
+    def __new__(mcl, name, bases, nmspc):
+        """Attach a list of proxy methods to a new class."""
+        proxy_methods = (
+            'get_context', 'pending', 'send', 'write', 'recv', 'read',
+            'renegotiate', 'bind', 'listen', 'connect', 'accept',
+            'setblocking', 'fileno', 'close', 'get_cipher_list',
+            'getpeername', 'getsockname', 'getsockopt', 'setsockopt',
+            'makefile', 'get_app_data', 'set_app_data', 'state_string',
+            'sock_shutdown', 'get_peer_certificate', 'want_read',
+            'want_write', 'set_connect_state', 'set_accept_state',
+            'connect_ex', 'sendall', 'settimeout', 'gettimeout',
+            'shutdown',
+        )
+        proxy_methods_no_args = (
+            'shutdown',
+        )
+
+        def lock_decorator(method):
+            """Create a proxy method for a new class."""
+            def proxy_wrapper(self, *args):
+                self._lock.acquire()
+                try:
+                    new_args = (
+                        args[:] if method not in proxy_methods_no_args else []
+                    )
+                    return getattr(self._ssl_conn, method)(*new_args)
+                finally:
+                    self._lock.release()
+            return proxy_wrapper
+        for m in proxy_methods:
+            nmspc[m] = lock_decorator(m)
+            nmspc[m].__name__ = m
+
+        # Doesn't work via super() for some reason.
+        # Falling back to type() instead:
+        return type(name, bases, nmspc)
+
+
+@six.add_metaclass(SSLConnectionProxyMeta)
 class SSLConnection:
     """A thread-safe wrapper for an SSL.Connection.
 
@@ -143,33 +187,6 @@ class SSLConnection:
         """Initialize SSLConnection instance."""
         self._ssl_conn = SSL.Connection(*args)
         self._lock = threading.RLock()
-
-    for f in ('get_context', 'pending', 'send', 'write', 'recv', 'read',
-              'renegotiate', 'bind', 'listen', 'connect', 'accept',
-              'setblocking', 'fileno', 'close', 'get_cipher_list',
-              'getpeername', 'getsockname', 'getsockopt', 'setsockopt',
-              'makefile', 'get_app_data', 'set_app_data', 'state_string',
-              'sock_shutdown', 'get_peer_certificate', 'want_read',
-              'want_write', 'set_connect_state', 'set_accept_state',
-              'connect_ex', 'sendall', 'settimeout', 'gettimeout'):
-        exec("""def %s(self, *args):
-        self._lock.acquire()
-        try:
-            return self._ssl_conn.%s(*args)
-        finally:
-            self._lock.release()
-""" % (f, f))
-
-    def shutdown(self, *args):
-        """Shutdown the SSL connection.
-
-        Ignore all incoming args since pyOpenSSL.socket.shutdown takes no args.
-        """
-        self._lock.acquire()
-        try:
-            return self._ssl_conn.shutdown()
-        finally:
-            self._lock.release()
 
 
 class pyOpenSSLAdapter(Adapter):

--- a/cheroot/test/test_ssl.py
+++ b/cheroot/test/test_ssl.py
@@ -1,0 +1,147 @@
+"""Tests for TLS/SSL support."""
+# -*- coding: utf-8 -*-
+# vim: set fileencoding=utf-8 :
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+import threading
+import time
+from unittest.mock import (  # FIXME: replace it with pytest-mock
+    patch, MagicMock
+)
+
+import pytest
+import six
+import trustme
+
+from .._compat import bton, ntou
+from ..server import Gateway, HTTPServer, get_ssl_adapter_class
+# from ..ssl import builtin, pyopenssl
+from ..testing import (
+    ANY_INTERFACE_IPV4,
+    # get_server_client,
+    _get_conn_data,
+)
+
+
+fails_under_py3 = pytest.mark.xfail(
+    six.PY3,
+    reason='Fails under Python 3',
+)
+
+
+class HelloWorldGateway(Gateway):
+    """Gateway responding with Hello World to root URI."""
+
+    def respond(self):
+        """Respond with dummy content via HTTP."""
+        req = self.req
+        req_uri = bton(req.uri)
+        if req_uri == '/':
+            req.status = b'200 OK'
+            req.ensure_headers_sent()
+            req.write(b'Hello world!')
+            return
+        return super(HelloWorldGateway, self).respond()
+
+
+def make_tls_http_server(bind_addr, ssl_adapter):
+    """Create and start an HTTP server bound to bind_addr."""
+    httpserver = HTTPServer(
+        bind_addr=bind_addr,
+        gateway=HelloWorldGateway,
+    )
+    # httpserver.gateway = HelloWorldGateway
+    httpserver.ssl_adapter = ssl_adapter
+
+    threading.Thread(target=httpserver.safe_start).start()
+
+    while not httpserver.ready:
+        time.sleep(0.1)
+
+    return httpserver
+
+
+@pytest.fixture
+def tls_http_server():
+    """Provision a server creator as a fixture."""
+    def start_srv():
+        bind_addr, ssl_adapter = yield
+        httpserver = make_tls_http_server(bind_addr, ssl_adapter)
+        yield httpserver
+        yield httpserver
+
+    srv_creator = iter(start_srv())
+    next(srv_creator)
+    yield srv_creator
+    try:
+        while True:
+            httpserver = next(srv_creator)
+            if httpserver is not None:
+                httpserver.stop()
+    except StopIteration:
+        pass
+
+
+@pytest.fixture
+def ca():
+    """Provide a certificate authority via fixture."""
+    ca = trustme.CA()
+    yield ca
+    del ca
+
+
+@pytest.mark.parametrize(
+    'adapter_type',
+    (
+        'builtin',
+        pytest.param('pyopenssl', marks=fails_under_py3),
+    ),
+)
+def test_ssl_adapters(tls_http_server, ca, adapter_type):
+    """Test ability to connect to server via HTTPS using adapters."""
+    interface, host, port = _get_conn_data(ANY_INTERFACE_IPV4)
+    cert = ca.issue_server_cert(ntou(interface), )
+    with ca.cert_pem.tempfile() as ca_temp_path:
+        with cert.cert_chain_pems[0].tempfile() as cert_temp_path:
+            tls_adapter_cls = get_ssl_adapter_class(name=adapter_type)
+            if adapter_type == 'builtin':
+                # Temporary patch chain loading
+                # as it fails for some reason:
+                with patch('ssl.SSLContext.load_cert_chain', MagicMock):
+                    tls_adapter = tls_adapter_cls(
+                        cert_temp_path, ca_temp_path,
+                    )
+            else:
+                tls_adapter = tls_adapter_cls(
+                    cert_temp_path, ca_temp_path,
+                )
+            # tls_adapter.context = tls_adapter.get_context()
+            if adapter_type == 'pyopenssl':
+                from OpenSSL import SSL
+                ctx = SSL.Context(SSL.SSLv23_METHOD)
+                tls_adapter.context = ctx
+            cert.configure_cert(tls_adapter.context)
+            tlshttpserver = tls_http_server.send(
+                (
+                    (interface, port),
+                    tls_adapter,
+                )
+            )
+
+            # testclient = get_server_client(tlshttpserver)
+            # testclient.get('/')
+
+            interface, host, port = _get_conn_data(
+                tlshttpserver.bind_addr
+            )
+
+            import requests
+            resp = requests.get(
+                'https://' + interface + ':' + str(port) + '/',
+                verify=ca_temp_path
+            )
+
+        assert resp.status_code == 200
+        assert resp.text == 'Hello world!'

--- a/cheroot/testing.py
+++ b/cheroot/testing.py
@@ -75,16 +75,23 @@ def native_server():
 
 class _TestClient:
     def __init__(self, server):
-        self._interface, self._host, self._port = _get_conn_data(server)
-        self._http_connection = self.get_connection()
+        self._interface, self._host, self._port = _get_conn_data(
+            server.bind_addr
+        )
         self.server_instance = server
+        self._http_connection = self.get_connection()
 
     def get_connection(self):
         name = '{interface}:{port}'.format(
             interface=self._interface,
             port=self._port,
         )
-        return http_client.HTTPConnection(name)
+        conn_cls = (
+            http_client.HTTPConnection
+            if self.server_instance.ssl_adapter is None else
+            http_client.HTTPSConnection
+        )
+        return conn_cls(name)
 
     def request(
         self, uri, method='GET', headers=None, http_conn=None,
@@ -123,11 +130,11 @@ def _probe_ipv6_sock(interface):
     return False
 
 
-def _get_conn_data(server):
-    if isinstance(server.bind_addr, tuple):
-        host, port = server.bind_addr
+def _get_conn_data(bind_addr):
+    if isinstance(bind_addr, tuple):
+        host, port = bind_addr
     else:
-        host, port = server.bind_addr, 0
+        host, port = bind_addr, 0
 
     interface = webtest.interface(host)
 

--- a/setup.py
+++ b/setup.py
@@ -76,6 +76,10 @@ params = dict(
 
             'pytest-cov',
             'backports.unittest_mock',
+
+            # TLS
+            'trustme>=0.4.0',
+            'pyopenssl',
         ],
     },
     setup_requires=[


### PR DESCRIPTION
* **What kind of change does this PR introduce?**
  - [x] bug fix
  - [ ] feature
  - [ ] docs update
  - [x] tests/coverage improvement
  - [x] refactoring
  - [ ] other



* **What is the related issue number (starting with `#`)**
#6 (`cheroot.ssl.pyopenssl` is now importable from under Python 3, but still doesn't work)
#95 (origins of testing SSL, added `trustme` for generation of CA and certs in runtime)


* **What is the current behavior?** (You can also link to an open issue here)
Mess in `cheroot.makefile`, `cheroot.ssl.pyopenssl` import fails under Python 3 (trying to inherit class from function :see_no_evil:), no SSL tests, no way to generate test certificates.


* **What is the new behavior (if this is a feature change)?**
New test for adapters in the wild, makefile has separately importable `StreamWriter` and `StreamReader`, 


* **Other information**:
https://gitter.im/cherrypy/cherrypy?at=5b871411c2bd5d117aefa6db

* **Checklist**:

  - [≈] I think the code is well written
  - [≈] I wrote [good commit messages][1]
  - [≈] I have [squashed related commits together][2] after the changes have been approved
  - [ ] Unit tests for the changes exist
  - [x] Integration tests for the changes exist (if applicable)
  - [x] I used the same coding conventions as the rest of the project
  - [x] The new code doesn't generate linter offenses
  - [ ] Documentation reflects the changes
  - [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences

[1]: http://chris.beams.io/posts/git-commit/
[2]: https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cherrypy/cheroot/109)
<!-- Reviewable:end -->
