### PR TITLE
Apply chmod on UNIX socket after creation

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,10 @@
+v6.5.1
+======
+- :issue:`93` via :pr:`110`: Improve UNIX socket fs access mode
+  in :py:meth:`cheroot.server.HTTPServer.prepare` on a file socket
+  when starting to listen to it.
+
+
 v6.5.0
 ======
 

--- a/cheroot/server.py
+++ b/cheroot/server.py
@@ -1846,8 +1846,8 @@ class HTTPServer:
     @staticmethod
     def resolve_real_bind_addr(socket_):
         """Retrieve actual bind addr from bound socket."""
-        # TODO: keep requested bind_addr separate real bound_addr (port is
-        # different in case of ephemeral port 0)
+        # FIXME: keep requested bind_addr separate real bound_addr (port
+        # is different in case of ephemeral port 0)
         bind_addr = socket_.getsockname()
         if socket_.family in (
             # Windows doesn't have socket.AF_UNIX, so not using it in check


### PR DESCRIPTION
Fixes #93

* **What kind of change does this PR introduce?**
  - [X] bug fix
  - [ ] feature
  - [ ] docs update
  - [ ] tests/coverage improvement
  - [ ] refactoring
  - [ ] other



* **What is the related issue number (starting with `#`)**
#93 


* **What is the current behavior?** (You can also link to an open issue here)
code unlinks the socket file and then immediately tries to chmod it


* **What is the new behavior (if this is a feature change)?**
it should chmod after bind


* **Other information**:
Very first appearance: https://github.com/cherrypy/cheroot/commit/6ced9fd2f7d23c9e4db78894d616ed8cc5e83738#diff-920de15fced9e5f9697efed08f3c207dR214

* **Checklist**:

  - [ ] I think the code is well written
  - [x] I wrote [good commit messages][1]
  - [x] I have [squashed related commits together][2] after the changes have been approved
  - [ ] Unit tests for the changes exist
  - [ ] Integration tests for the changes exist (if applicable)
  - [x] I used the same coding conventions as the rest of the project
  - [x] The new code doesn't generate linter offenses
  - [ ] Documentation reflects the changes
  - [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences

[1]: http://chris.beams.io/posts/git-commit/
[2]: https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cherrypy/cheroot/110)
<!-- Reviewable:end -->
