### PR TITLE
don't use SO_REUSEADDR when port is ephemeral

### DIFF
--- a/cheroot/server.py
+++ b/cheroot/server.py
@@ -1832,7 +1832,7 @@ class HTTPServer:
             FS_PERMS_SET = False
 
         try:
-            sock = self.bind_socket(sock, bind_addr)
+            sock = self.\(sock, bind_addr)
         except socket.error:
             sock.close()
             raise
@@ -1862,18 +1862,21 @@ class HTTPServer:
         """Create and prepare the socket object."""
         sock = socket.socket(family, type, proto)
         prevent_socket_inheritance(sock)
-        if not IS_WINDOWS:
+        
+        host, port = bind_addr[:2]
+        
+        if not IS_WINDOWS and port != 0:
             # Windows has different semantics for SO_REUSEADDR,
-            # so don't set it.
+            # so don't set it
             # https://msdn.microsoft.com/en-us/library/ms740621(v=vs.85).aspx
+            # Also refer to Issue #114 for why adding SO_REUSEADDR under linux
+            # when the port is ephemeral is bad
             sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
         if nodelay and not isinstance(bind_addr, str):
             sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
 
         if ssl_adapter is not None:
             sock = ssl_adapter.bind(sock)
-
-        host, port = bind_addr[:2]
 
         # If listening on the IPV6 any address ('::' = IN6ADDR_ANY),
         # activate dual-stack. See

--- a/cheroot/server.py
+++ b/cheroot/server.py
@@ -1867,11 +1867,16 @@ class HTTPServer:
         IS_EPHEMERAL_PORT = port == 0
 
         if not (IS_WINDOWS or IS_EPHEMERAL_PORT):
-            # Windows has different semantics for SO_REUSEADDR,
-            # so don't set it
-            # https://msdn.microsoft.com/en-us/library/ms740621(v=vs.85).aspx
-            # Also refer to Issue #114 for why adding SO_REUSEADDR under linux
-            # when the port is ephemeral is bad
+            """Enable SO_REUSEADDR for the current socket.
+
+            Skip for Windows (has different semantics)
+            or ephemeral ports (can steal ports from others).
+
+            Refs:
+            * https://msdn.microsoft.com/en-us/library/ms740621(v=vs.85).aspx
+            * https://github.com/cherrypy/cheroot/issues/114
+            * https://gavv.github.io/blog/ephemeral-port-reuse/
+            """
             sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
         if nodelay and not isinstance(bind_addr, str):
             sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)

--- a/cheroot/server.py
+++ b/cheroot/server.py
@@ -1862,9 +1862,9 @@ class HTTPServer:
         """Create and prepare the socket object."""
         sock = socket.socket(family, type, proto)
         prevent_socket_inheritance(sock)
-        
+
         host, port = bind_addr[:2]
-        
+
         if not IS_WINDOWS and port != 0:
             # Windows has different semantics for SO_REUSEADDR,
             # so don't set it

--- a/cheroot/server.py
+++ b/cheroot/server.py
@@ -1864,8 +1864,9 @@ class HTTPServer:
         prevent_socket_inheritance(sock)
 
         host, port = bind_addr[:2]
+        IS_EPHEMERAL_PORT = port == 0
 
-        if not IS_WINDOWS and port != 0:
+        if not (IS_WINDOWS or IS_EPHEMERAL_PORT):
             # Windows has different semantics for SO_REUSEADDR,
             # so don't set it
             # https://msdn.microsoft.com/en-us/library/ms740621(v=vs.85).aspx

--- a/cheroot/server.py
+++ b/cheroot/server.py
@@ -1832,7 +1832,7 @@ class HTTPServer:
             FS_PERMS_SET = False
 
         try:
-            sock = self.\(sock, bind_addr)
+            sock = self.bind_socket(sock, bind_addr)
         except socket.error:
             sock.close()
             raise


### PR DESCRIPTION
Issue #114

* **What kind of change does this PR introduce?**
  - [x] bug fix
  - [X] feature
  - [ ] docs update
  - [ ] tests/coverage improvement
  - [ ] refactoring
  - [ ] other



* **What is the related issue number (starting with `#`)**

Fixes #114 

* **What is the current behavior?** (You can also link to an open issue here)

Applications bound to port 0 may steal other running applications binds.

* **What is the new behavior (if this is a feature change)?**

Applications bound to port 0 will not set SO_REUSEADDR, and thus will not steal other applications binds.

* **Other information**:


* **Checklist**:

  - [X] I think the code is well written
  - [X] I wrote [good commit messages][1]
  - [X] I have [squashed related commits together][2] after the changes have been approved
  - [ ] Unit tests for the changes exist
  - [ ] Integration tests for the changes exist (if applicable)
  - [X] I used the same coding conventions as the rest of the project
  - [X] The new code doesn't generate linter offenses
  - [ ] Documentation reflects the changes
  - [X] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences

[1]: http://chris.beams.io/posts/git-commit/
[2]: https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cherrypy/cheroot/143)
<!-- Reviewable:end -->
