### PR TITLE
Fix Circle CI builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,7 +33,14 @@ jobs:
 
     - run: pip install tox tox-pyenv
     - checkout
-    - run: tox -e py27,py34,py35,py36,py37,pypy3 -- -p no:sugar
+    - run:
+        name: Run tests
+        command: tox -e py27,py34,py35,py36,py37,pypy3 -- -p no:sugar
+        # Environment variables for py-cryptography library
+        environment:
+          LDFLAGS: "-L/usr/local/opt/openssl/lib"
+          CPPFLAGS: "-I/usr/local/opt/openssl/include"
+          PKG_CONFIG_PATH: "/usr/local/opt/openssl/lib/pkgconfig"
 
   linux-build:
     parallelism: 4

--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,7 @@ whitelist_externals =
 commands =
     rm -rf .eggs/
     bash -c "if [[ '{env:CIRCLECI:disabled}' == 'disabled' ]]; then pytest --testmon-off {posargs}; fi"
-    bash -c "if [[ '{env:CIRCLECI:disabled}' != 'disabled' ]]; then circleci tests glob **/test/**.py | circleci tests split --split-by=timings | xargs pytest --testmon-off {posargs}; fi"
+    bash -c "if [[ '{env:CIRCLECI:disabled}' != 'disabled' ]]; then circleci tests glob **/test/**.py | circleci tests split --split-by=timings | grep -v '__init__.py' | xargs pytest --testmon-off {posargs}; fi"
     codecov -f coverage.xml -X gcov
 usedevelop = True
 extras = testing


### PR DESCRIPTION
❓ **What kind of change does this PR introduce?**
  - [ ] 🐞 bug fix
  - [ ] 🐣 feature
  - [ ] 📋 docs update
  - [ ] 📋 tests/coverage improvement
  - [X] 📋 refactoring
  - [ ] 💥 other

📋 **What is the related issue number (starting with `#`)**

Fix up the tests failing on Travis.

❓ **What is the current behavior?** (You can also link to an open issue here)

Travis builds fail due to a PEP compliance error.

❓ **What is the new behavior (if this is a feature change)?**

They no longer fail.

📋 **Other information**:

CircleCI builds as well as `pre-commit-failing` builds fail due to an underlying issue with Asteroid. They currently have no builds that work with both Python 2.7 and Python 3.7. As such we might need to rework our testing strategy on that front, as it seems they don't have a build for Python 3.7 yet either.

📋 **Checklist**:

  - [X] I think the code is well written
  - [X] I wrote [good commit messages][1]
  - [X] I have [squashed related commits together][2] after the changes have been approved
  - [ ] Unit tests for the changes exist
  - [ ] Integration tests for the changes exist (if applicable)
  - [X] I used the same coding conventions as the rest of the project
  - [X] The new code doesn't generate linter offenses
  - [ ] Documentation reflects the changes
  - [X] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences

[1]: http://chris.beams.io/posts/git-commit/
[2]: https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cherrypy/cheroot/146)
<!-- Reviewable:end -->
