### PR TITLE
Use VM-based infrastructure, sudo: required is no longer required

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 conditions: v1
 
 dist: xenial
-sudo: required
 language: python
 
 python:


### PR DESCRIPTION


❓ **What kind of change does this PR introduce?**
  - [ ] 🐞 bug fix
  - [ ] 🐣 feature
  - [ ] 📋 docs update
  - [ ] 📋 tests/coverage improvement
  - [ ] 📋 refactoring
  - [x] 💥 other

📋 **What is the related issue number (starting with `#`)**

n/a

❓ **What is the current behavior?** (You can also link to an open issue here)

It now uses VM-based infrastructure since 7 December
https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration

❓ **What is the new behavior (if this is a feature change)?**

No change, removes redundant config

📋 **Other information**:

n/a

📋 **Checklist**:

  - [x] I think the code is well written
  - [x] I wrote [good commit messages][1]
  - [ ] I have [squashed related commits together][2] after the changes have been approved
  - [x] Unit tests for the changes exist
  - [x] Integration tests for the changes exist (if applicable)
  - [x] I used the same coding conventions as the rest of the project
  - [x] The new code doesn't generate linter offenses
  - [ ] Documentation reflects the changes
  - [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences

[1]: http://chris.beams.io/posts/git-commit/
[2]: https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cherrypy/cheroot/148)
<!-- Reviewable:end -->
