### PR TITLE
Make SCRIPT_NAME environ variable optional

### DIFF
--- a/cheroot/test/test_dispatch.py
+++ b/cheroot/test/test_dispatch.py
@@ -1,0 +1,51 @@
+"""Tests for the HTTP server."""
+# -*- coding: utf-8 -*-
+# vim: set fileencoding=utf-8 :
+
+from __future__ import absolute_import, division, print_function
+
+from cheroot.wsgi import PathInfoDispatcher
+
+
+def wsgi_invoke(app, environ):
+    """Serve 1 requeset from a WSGI application."""
+    response = {}
+
+    def start_response(status, headers):
+        response.update({
+            'status': status,
+            'headers': headers,
+        })
+
+    response['body'] = b''.join(
+        app(environ, start_response)
+    )
+
+    return response
+
+
+def test_dispatch_no_script_name():
+    """Despatch despite lack of SCRIPT_NAME in environ."""
+    # Bare bones WSGI hello world app (from PEP 333).
+    def app(environ, start_response):
+        start_response('200 OK', [
+            ('Content-Type', 'text/plain; charset=utf-8'),
+        ])
+        return [u'Hello, world!'.encode('utf-8')]
+
+    # Build a dispatch table.
+    d = PathInfoDispatcher([
+        ('/', app),
+    ])
+
+    # Dispatch a request without `SCRIPT_NAME`.
+    response = wsgi_invoke(d, {
+        'PATH_INFO': '/foo',
+    })
+    assert response == {
+        'status': '200 OK',
+        'headers': [
+            ('Content-Type', 'text/plain; charset=utf-8'),
+        ],
+        'body': b'Hello, world!',
+    }

--- a/cheroot/wsgi.py
+++ b/cheroot/wsgi.py
@@ -404,7 +404,7 @@ class PathInfoDispatcher:
             # The apps list should be sorted by length, descending.
             if path.startswith(p + '/') or path == p:
                 environ = environ.copy()
-                environ['SCRIPT_NAME'] = environ['SCRIPT_NAME'] + p
+                environ['SCRIPT_NAME'] = environ.get('SCRIPT_NAME', '') + p
                 environ['PATH_INFO'] = path[len(p):]
                 return app(environ, start_response)
 


### PR DESCRIPTION
PEP 333 makes this CGI-style variable optional.  See the the section titled "environ variables":

> The following variables must be present, unless their value would be an empty string, in which case they may be omitted, except as otherwise noted below.

Some WSGI middleware does not set this environ variable.  When combined with `cheroot.wsgi.PathInfoDispatcher`, there is a confusing `KeyError` exception that may not be correctly be translated to an HTTP 500 response.

This change makes the variable optional.

❓ **What kind of change does this PR introduce?**
  - [ x] 🐞 bug fix
  - [ ] 🐣 feature
  - [ ] 📋 docs update
  - [ ] 📋 tests/coverage improvement
  - [ ] 📋 refactoring
  - [ ] 💥 other

📋 **What is the related issue number (starting with `#`)**

#

❓ **What is the current behavior?** (You can also link to an open issue here)

A `KeyError` exception is raised when dispatching a request that does not set `SCRIPT_NAME` in the WSGI `environ` dictionary.  Unless the `PathInfoDispatch` is wrapped into some other WSGI middleware, the exception may not be translated to an HTTP 500 error.

❓ **What is the new behavior (if this is a feature change)?**

The request is routed as though `SCRIPT_NAME` contained an empty string.

📋 **Other information**:

See PEP 333 (and the quote above).

📋 **Checklist**:

  - [x] I think the code is well written
  - [x] I wrote [good commit messages][1]
  - [x] I have [squashed related commits together][2] after the changes have been approved
  - [x] Unit tests for the changes exist
  - [ ] Integration tests for the changes exist (if applicable)
  - [ ] I used the same coding conventions as the rest of the project
  - [ ] The new code doesn't generate linter offenses
  - [ ] Documentation reflects the changes
  - [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences

[1]: http://chris.beams.io/posts/git-commit/
[2]: https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cherrypy/cheroot/149)
<!-- Reviewable:end -->
