### PR TITLE
 SSL `error: [Errno 0] Error` is present also on Python 3.7

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ v6.5.5
 - :issue:`99` via :pr:`186': Sockets now collect statistics (bytes
   read and written) on Python 3 same as Python 2.
 
-- :cp-issue:`1618` via :pr:`180`: Ignore OpenSSL's 1.0+ Error 0
+- :cp-issue:`1618` via :pr:`180`: Ignore OpenSSL's 1.1+ Error 0
   under any Python while wrapping a socket.
 
 v6.5.4
@@ -93,7 +93,7 @@ v6.3.2
 v6.3.1
 ======
 
-- :cp-issue:`1618`: Ignore OpenSSL's 1.0+ Error 0 under Python 2 while
+- :cp-issue:`1618`: Ignore OpenSSL's 1.1+ Error 0 under Python 2 while
   wrapping a socket.
 
 v6.3.0

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,6 @@
+- :cp-issue:`1618` via :pr:`180`: Ignore OpenSSL's 1.0+ Error 0
+  under any Python while wrapping a socket.
+
 v6.5.4
 ======
 

--- a/cheroot/ssl/builtin.py
+++ b/cheroot/ssl/builtin.py
@@ -153,8 +153,7 @@ class BuiltinSSLAdapter(Adapter):
         except generic_socket_error as exc:
             """It is unclear why exactly this happens.
 
-            It's reproducible only under Python<=3.6 with openssl>1.0
-            and stdlib ``ssl`` wrapper.
+            It's reproducible only with openssl>1.0 and stdlib ``ssl`` wrapper.
             In CherryPy it's triggered by Checker plugin, which connects
             to the app listening to the socket port in TLS mode via plain
             HTTP during startup (from the same process).
@@ -163,9 +162,8 @@ class BuiltinSSLAdapter(Adapter):
             Ref: https://github.com/cherrypy/cherrypy/issues/1618
             """
             is_error0 = exc.args == (0, 'Error')
-            ssl_doesnt_handle_error0 = IS_ABOVE_OPENSSL10 and IS_BELOW_PY37
 
-            if is_error0 and ssl_doesnt_handle_error0:
+            if is_error0 and IS_ABOVE_OPENSSL10:
                 return EMPTY_RESULT
             raise
         return s, self.get_environ(s)

--- a/cheroot/ssl/builtin.py
+++ b/cheroot/ssl/builtin.py
@@ -10,8 +10,6 @@ To use this module, set ``HTTPServer.ssl_adapter`` to an instance of
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
-import sys
-
 try:
     import ssl
 except ImportError:
@@ -38,9 +36,6 @@ else:
     import socket
     generic_socket_error = socket.error
     del socket
-
-
-IS_BELOW_PY37 = sys.version_info[:2] < (3, 7)
 
 
 def _assert_ssl_exc_contains(exc, *msgs):


### PR DESCRIPTION
❓ **What kind of change does this PR introduce?**
  - [x] 🐞 bug fix
  - [ ] 🐣 feature
  - [ ] 📋 docs update
  - [ ] 📋 tests/coverage improvement
  - [ ] 📋 refactoring
  - [ ] 💥 other

📋 **What is the related issue number (starting with `#`)**

https://github.com/cherrypy/cherrypy/issues/1618

❓ **What is the current behavior?** (You can also link to an open issue here)

https://github.com/cherrypy/cherrypy/issues/1618
Error is still present with Python 3.7.2, as reported by users on Windows and Linux machines.

❓ **What is the new behavior (if this is a feature change)?**

Always suppress this error.

📋 **Other information**:



📋 **Checklist**:

  - [x] I think the code is well written
  - [x] I wrote [good commit messages][1]
  - [x] I have [squashed related commits together][2] after the changes have been approved
  - [ ] Unit tests for the changes exist
  - [ ] Integration tests for the changes exist (if applicable)
  - [x] I used the same coding conventions as the rest of the project
  - [x] The new code doesn't generate linter offenses
  - [ ] Documentation reflects the changes
  - [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences

[1]: http://chris.beams.io/posts/git-commit/
[2]: https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cherrypy/cheroot/180)
<!-- Reviewable:end -->
