### PR TITLE
Request based workers

### DIFF
--- a/cheroot/connections.py
+++ b/cheroot/connections.py
@@ -226,7 +226,10 @@ class ConnectionManager:
 
             conn = self.server.ConnectionClass(self.server, s, mf)
 
-            if not isinstance(self.server.bind_addr, six.string_types):
+            if not isinstance(
+                    self.server.bind_addr,
+                    (six.text_type, six.binary_type),
+            ):
                 # optional values
                 # Until we do DNS lookups, omit REMOTE_HOST
                 if addr is None:  # sometimes this can happen

--- a/cheroot/connections.py
+++ b/cheroot/connections.py
@@ -61,16 +61,17 @@ class ConnectionManager:
 
         # Check for too many open connections.
         conns = list(self.connections.items())
-        if self.server.keep_alive_conn_limit is not None:
-            [self.close(conn[0]) for conn in conns[:-self.server.keep_alive_conn_limit]]
-            conns = conns[-self.server.keep_alive_conn_limit:]
+        ka_limit = self.server.keep_alive_conn_limit
+        if ka_limit is not None:
+            [self._close(conn[0]) for conn in conns[:-ka_limit]]
+            conns = conns[-ka_limit:]
 
         # Check for old connections.
         now = time.time()
         for (conn, (ctime, _)) in conns:
             # Oldest connection out of the currently available ones.
             if (ctime + self.server.timeout) < now:
-                self.close(conn)
+                self._close(conn)
             else:
                 break
 
@@ -121,7 +122,7 @@ class ConnectionManager:
         del self.connections[conn]
         return conn
 
-    def close(self, conn):
+    def _close(self, conn):
         del self.connections[conn]
         conn.close()
 

--- a/cheroot/connections.py
+++ b/cheroot/connections.py
@@ -1,0 +1,135 @@
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+import io
+import six
+import socket
+
+from . import errors
+from .makefile import MakeFile
+
+
+try:
+    import fcntl
+except ImportError:
+    try:
+        from ctypes import windll, WinError
+        import ctypes.wintypes
+        _SetHandleInformation = windll.kernel32.SetHandleInformation
+        _SetHandleInformation.argtypes = [
+            ctypes.wintypes.HANDLE,
+            ctypes.wintypes.DWORD,
+            ctypes.wintypes.DWORD,
+        ]
+        _SetHandleInformation.restype = ctypes.wintypes.BOOL
+    except ImportError:
+        def prevent_socket_inheritance(sock):
+            """Stub inheritance prevention.
+
+            Dummy function, since neither fcntl nor ctypes are available.
+            """
+            pass
+    else:
+        def prevent_socket_inheritance(sock):
+            """Mark the given socket fd as non-inheritable (Windows)."""
+            if not _SetHandleInformation(sock.fileno(), 1, 0):
+                raise WinError()
+else:
+    def prevent_socket_inheritance(sock):
+        """Mark the given socket fd as non-inheritable (POSIX)."""
+        fd = sock.fileno()
+        old_flags = fcntl.fcntl(fd, fcntl.F_GETFD)
+        fcntl.fcntl(fd, fcntl.F_SETFD, old_flags | fcntl.FD_CLOEXEC)
+
+
+class ConnectionManager:
+
+    def __init__(self, server):
+        self.server = server
+
+    def from_server_socket(self, server_socket):
+        try:
+            s, addr = server_socket.accept()
+            if self.server.stats['Enabled']:
+                self.server.stats['Accepts'] += 1
+            prevent_socket_inheritance(s)
+            if hasattr(s, 'settimeout'):
+                s.settimeout(self.server.timeout)
+
+            mf = MakeFile
+            ssl_env = {}
+            # if ssl cert and key are set, we try to be a secure HTTP server
+            if self.server.ssl_adapter is not None:
+                try:
+                    s, ssl_env = self.server.ssl_adapter.wrap(s)
+                except errors.NoSSLError:
+                    msg = (
+                        'The client sent a plain HTTP request, but '
+                        'this server only speaks HTTPS on this port.'
+                    )
+                    buf = [
+                        '%s 400 Bad Request\r\n' % self.server.protocol,
+                        'Content-Length: %s\r\n' % len(msg),
+                        'Content-Type: text/plain\r\n\r\n',
+                        msg,
+                    ]
+
+                    sock_to_make = s if not six.PY2 else s._sock
+                    wfile = mf(sock_to_make, 'wb', io.DEFAULT_BUFFER_SIZE)
+                    try:
+                        wfile.write(''.join(buf).encode('ISO-8859-1'))
+                    except socket.error as ex:
+                        if ex.args[0] not in errors.socket_errors_to_ignore:
+                            raise
+                    return
+                if not s:
+                    return
+                mf = self.server.ssl_adapter.makefile
+                # Re-apply our timeout since we may have a new socket object
+                if hasattr(s, 'settimeout'):
+                    s.settimeout(self.server.timeout)
+
+            conn = self.server.ConnectionClass(self.server, s, mf)
+
+            if not isinstance(self.server.bind_addr, six.string_types):
+                # optional values
+                # Until we do DNS lookups, omit REMOTE_HOST
+                if addr is None:  # sometimes this can happen
+                    # figure out if AF_INET or AF_INET6.
+                    if len(s.getsockname()) == 2:
+                        # AF_INET
+                        addr = ('0.0.0.0', 0)
+                    else:
+                        # AF_INET6
+                        addr = ('::', 0)
+                conn.remote_addr = addr[0]
+                conn.remote_port = addr[1]
+
+            conn.ssl_env = ssl_env
+            return conn
+
+        except socket.timeout:
+            # The only reason for the timeout in start() is so we can
+            # notice keyboard interrupts on Win32, which don't interrupt
+            # accept() by default
+            return
+        except socket.error as ex:
+            if self.server.stats['Enabled']:
+                self.server.stats['Socket Errors'] += 1
+            if ex.args[0] in errors.socket_error_eintr:
+                # I *think* this is right. EINTR should occur when a signal
+                # is received during the accept() call; all docs say retry
+                # the call, and I *think* I'm reading it right that Python
+                # will then go ahead and poll for and handle the signal
+                # elsewhere. See
+                # https://github.com/cherrypy/cherrypy/issues/707.
+                return
+            if ex.args[0] in errors.socket_errors_nonblocking:
+                # Just try again. See
+                # https://github.com/cherrypy/cherrypy/issues/479.
+                return
+            if ex.args[0] in errors.socket_errors_to_ignore:
+                # Our socket was closed.
+                # See https://github.com/cherrypy/cherrypy/issues/686.
+                return
+            raise

--- a/cheroot/connections.py
+++ b/cheroot/connections.py
@@ -6,15 +6,14 @@ __metaclass__ = type
 import io
 import os
 import select
-import six
 import socket
 import time
+from collections import OrderedDict
 
 from . import errors
 from .makefile import MakeFile
 
-from collections import OrderedDict
-
+import six
 
 try:
     import fcntl
@@ -115,7 +114,7 @@ class ConnectionManager:
         back if it should be examined again for another request.
 
         Args:
-            server_socket: ServerSocket instance to listen to for new
+            server_socket (socket.socket): Socket to listen to for new
             connections.
         Returns:
             cheroot.server.HTTPConnection instance, or None.

--- a/cheroot/connections.py
+++ b/cheroot/connections.py
@@ -268,3 +268,9 @@ class ConnectionManager:
                 # See https://github.com/cherrypy/cherrypy/issues/686.
                 return
             raise
+
+    def close(self):
+        """Close all monitored connections."""
+        for conn in self.connections[:]:
+            conn.close()
+        self.connections = []

--- a/cheroot/makefile.py
+++ b/cheroot/makefile.py
@@ -282,6 +282,7 @@ class MakeFile_PY2(getattr(socket, '_fileobject', object)):
                 return buf.getvalue()
 
         def has_data(self):
+            """Return true if there is buffered data to read."""
             return bool(self._rbuf.getvalue())
 
     else:
@@ -401,6 +402,7 @@ class MakeFile_PY2(getattr(socket, '_fileobject', object)):
                 return ''.join(buffers)
 
         def has_data(self):
+            """Return true if there is buffered data to read."""
             return bool(self._rbuf)
 
 
@@ -420,6 +422,7 @@ if not six.PY2:
             return val
 
         def has_data(self):
+            """Return true if there is buffered data to read."""
             return bool(self.peek(1))
 
     class StreamWriter(BufferedWriter):

--- a/cheroot/makefile.py
+++ b/cheroot/makefile.py
@@ -235,6 +235,7 @@ class MakeFile_PY2(getattr(socket, '_fileobject', object)):
                         break
                     buf.write(data)
                 return buf.getvalue()
+
             else:
                 # Read until size bytes or \n or EOF seen, whichever comes
                 # first
@@ -279,6 +280,10 @@ class MakeFile_PY2(getattr(socket, '_fileobject', object)):
                     buf_len += n
                     # assert buf_len == buf.tell()
                 return buf.getvalue()
+
+        def has_data(self):
+            return bool(self._rbuf.getvalue())
+
     else:
         def read(self, size=-1):
             """Read data from the socket to buffer."""
@@ -395,6 +400,9 @@ class MakeFile_PY2(getattr(socket, '_fileobject', object)):
                     buf_len += n
                 return ''.join(buffers)
 
+        def has_data(self):
+            return bool(self._rbuf)
+
 
 if not six.PY2:
     class StreamReader(io.BufferedReader):
@@ -410,6 +418,9 @@ if not six.PY2:
             val = super().read(*args, **kwargs)
             self.bytes_read += len(val)
             return val
+
+        def has_data(self):
+            return bool(self.peek(1))
 
     class StreamWriter(BufferedWriter):
         """Socket stream writer."""

--- a/cheroot/makefile.py
+++ b/cheroot/makefile.py
@@ -423,7 +423,7 @@ if not six.PY2:
 
         def has_data(self):
             """Return true if there is buffered data to read."""
-            return bool(self.peek(1))
+            return len(self._read_buf) > self._read_pos
 
     class StreamWriter(BufferedWriter):
         """Socket stream writer."""

--- a/cheroot/server.py
+++ b/cheroot/server.py
@@ -1230,6 +1230,7 @@ class HTTPConnection:
     # Fields set by ConnectionManager.
     closeable = False
     last_used = None
+    ready_with_data = False
 
     def __init__(self, server, sock, makefile=MakeFile):
         """Initialize HTTPConnection instance.

--- a/cheroot/server.py
+++ b/cheroot/server.py
@@ -1227,6 +1227,9 @@ class HTTPConnection:
     peercreds_enabled = False
     peercreds_resolve_enabled = False
 
+    # Fields set by ConnectionManager.
+    closeable = False
+
     def __init__(self, server, sock, makefile=MakeFile):
         """Initialize HTTPConnection instance.
 

--- a/cheroot/server.py
+++ b/cheroot/server.py
@@ -1257,12 +1257,11 @@ class HTTPConnection:
     def communicate(self):
         """Read each request and respond appropriately.
 
-        Returns true if the connection should be kept open."""
+        Returns true if the connection should be kept open.
+        """
         request_seen = False
         try:
             req = self.RequestHandlerClass(self.server, self)
-
-            # This order of operations should guarantee correct pipelining.
             req.parse_request()
             if self.server.stats['Enabled']:
                 self.requests_seen += 1

--- a/cheroot/server.py
+++ b/cheroot/server.py
@@ -1274,7 +1274,7 @@ class HTTPConnection:
                 # Something went wrong in the parsing (and the server has
                 # probably already made a simple_response). Return and
                 # let the conn close.
-                return
+                return False
 
             request_seen = True
             req.respond()
@@ -1308,6 +1308,7 @@ class HTTPConnection:
                 repr(ex), level=logging.ERROR, traceback=True,
             )
             self._conditional_error(req, '500 Internal Server Error')
+        return False
 
     linger = False
 

--- a/cheroot/server.py
+++ b/cheroot/server.py
@@ -2059,6 +2059,7 @@ class HTTPServer:
                 sock.close()
             self.socket = None
 
+        self.connections.close()
         self.requests.stop(self.shutdown_timeout)
 
 

--- a/cheroot/server.py
+++ b/cheroot/server.py
@@ -1229,6 +1229,7 @@ class HTTPConnection:
 
     # Fields set by ConnectionManager.
     closeable = False
+    last_used = None
 
     def __init__(self, server, sock, makefile=MakeFile):
         """Initialize HTTPConnection instance.

--- a/cheroot/test/test_conn.py
+++ b/cheroot/test/test_conn.py
@@ -392,7 +392,6 @@ def test_keepalive(test_client, http_server_protocol):
 
 def test_keepalive_conn_management(test_client):
     """Test management of Keep-Alive connections."""
-
     test_client.server_instance.timeout = 2
 
     def connection():
@@ -413,7 +412,11 @@ def test_keepalive_conn_management(test_client):
         assert actual_resp_body == pov.encode()
         assert header_has_value('Connection', 'Keep-Alive', actual_headers)
 
-    disconnect_errors = (http_client.BadStatusLine, http_client.NotConnected)
+    disconnect_errors = (
+        http_client.BadStatusLine,
+        http_client.CannotSendRequest,
+        http_client.NotConnected,
+    )
 
     # Make a new connection.
     c1 = connection()
@@ -612,7 +615,7 @@ def test_HTTP11_pipelining(test_client):
         response = conn.response_class(conn.sock, method='GET')
         # there is a bug in python3 regarding the buffering of
         # ``conn.sock``. Until that bug get's fixed we will
-        # monkey patch the ``reponse`` instance.
+        # monkey patch the ``response`` instance.
         # https://bugs.python.org/issue23377
         if not six.PY2:
             response.fp = conn.sock.makefile('rb', 0)

--- a/cheroot/workers/threadpool.py
+++ b/cheroot/workers/threadpool.py
@@ -112,10 +112,14 @@ class WorkerThread(threading.Thread):
                 is_stats_enabled = self.server.stats['Enabled']
                 if is_stats_enabled:
                     self.start_time = time.time()
+                keep_conn_open = False
                 try:
-                    conn.communicate()
+                    keep_conn_open = conn.communicate()
                 finally:
-                    conn.close()
+                    if keep_conn_open:
+                        self.server.connections.put(conn)
+                    else:
+                        conn.close()
                     if is_stats_enabled:
                         self.requests_seen += self.conn.requests_seen
                         self.bytes_read += self.conn.rfile.bytes_read

--- a/cheroot/workers/threadpool.py
+++ b/cheroot/workers/threadpool.py
@@ -108,6 +108,11 @@ class WorkerThread(threading.Thread):
                 if conn is _SHUTDOWNREQUEST:
                     return
 
+                # Just close the connection and move on.
+                if conn.closeable:
+                    conn.close()
+                    continue
+
                 self.conn = conn
                 is_stats_enabled = self.server.stats['Enabled']
                 if is_stats_enabled:


### PR DESCRIPTION
❓ **What kind of change does this PR introduce?**
  - [X] 🐞 bug fix
  - [x] 🐣 feature
  - [ ] 📋 docs update
  - [ ] 📋 tests/coverage improvement
  - [ ] 📋 refactoring
  - [ ] 💥 other

📋 **What is the related issue number (starting with `#`)**

#91 

❓ **What is the current behavior?**

Worker threads are allocated a connection object, and that thread is occupied by that connection is closed or times out.

This can lead to the server having no spare threads to handle new incoming connections - even if there are no further requests coming over the used connections.

❓ **What is the new behavior (if this is a feature change)?**

We maintain a connection pool of open connections. Cheroot uses `select` to determine if any of the open connections or the server socket has any incoming data - we then either use an existing connection or accept a new connection, and pass that to the worker thread.

Once the worker thread has processed a request, it will pass the connection back to the connection pool (if it decides that the connection should not be closed). This allow threads to only be occupied by connections that are ready with a request.

📋 **Other information**:

The connection pool uses two settings - a new one to determine how many keep-alive connections to keep open (this only applies to connections which are not currently being handled by a thread).

It also uses the server socket timeout setting to determine when to close an idle keep-alive connection.

📋 **Checklist**:

  - [x] I think the code is well written
  - [x] I wrote [good commit messages][1]
  - [x] I have [squashed related commits together][2] after the changes have been approved
  - [x] Unit tests for the changes exist
  - [ ] Integration tests for the changes exist (if applicable)
  - [x] I used the same coding conventions as the rest of the project
  - [x] The new code doesn't generate linter offenses
  - [ ] Documentation reflects the changes
  - [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences

[1]: http://chris.beams.io/posts/git-commit/
[2]: https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cherrypy/cheroot/199)
<!-- Reviewable:end -->
