### PR TITLE
Fix race condition in threadpool shrink code.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,8 @@ v6.6.0
 - Revisit :pr:`85` under :pr:`221`. Now
   ``backports.functools_lru_cache`` is only
   required on Python 3.2 and earlier.
+- :cp-issue:`1206` via :pr:`204`: Fix race condition in
+  threadpool shrink code.
 
 v6.5.8
 ======

--- a/cheroot/workers/threadpool.py
+++ b/cheroot/workers/threadpool.py
@@ -4,6 +4,7 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 
+import collections
 import threading
 import time
 import socket
@@ -155,6 +156,7 @@ class ThreadPool:
         self._queue = queue.Queue(maxsize=accepted_queue_size)
         self._queue_put_timeout = accepted_queue_timeout
         self.get = self._queue.get
+        self._pending_shutdowns = collections.deque()
 
     def start(self):
         """Start the pool of threads."""
@@ -170,7 +172,8 @@ class ThreadPool:
     @property
     def idle(self):  # noqa: D401; irrelevant for properties
         """Number of worker threads which are idle. Read-only."""
-        return len([t for t in self._threads if t.conn is None])
+        idles = len([t for t in self._threads if t.conn is None])
+        return max(idles - len(self._pending_shutdowns), 0)
 
     def put(self, obj):
         """Put request into queue.
@@ -180,8 +183,16 @@ class ThreadPool:
                 waiting to be processed
         """
         self._queue.put(obj, block=True, timeout=self._queue_put_timeout)
-        if obj is _SHUTDOWNREQUEST:
-            return
+
+    def _clear_dead_threads(self):
+        # Remove any dead threads from our list
+        for t in self._threads:
+            if not t.isAlive():
+                self._threads.remove(t)
+                try:
+                    self._pending_shutdowns.popleft()
+                except IndexError:
+                    pass
 
     def grow(self, amount):
         """Spawn new worker threads (not above self.max)."""
@@ -208,10 +219,10 @@ class ThreadPool:
         """Kill off worker threads (not below self.min)."""
         # Grow/shrink the pool if necessary.
         # Remove any dead threads from our list
-        for t in self._threads:
-            if not t.is_alive():
-                self._threads.remove(t)
-                amount -= 1
+        amount -= len(self._pending_shutdowns)
+        self._clear_dead_threads()
+        if amount <= 0:
+            return
 
         # calculate the number of threads above the minimum
         n_extra = max(len(self._threads) - self.min, 0)
@@ -223,6 +234,7 @@ class ThreadPool:
         # to remove. As each request is processed by a worker, that worker
         # will terminate and be culled from the list.
         for n in range(n_to_remove):
+            self._pending_shutdowns.append(None)
             self._queue.put(_SHUTDOWNREQUEST)
 
     def stop(self, timeout=5):

--- a/cheroot/workers/threadpool.py
+++ b/cheroot/workers/threadpool.py
@@ -186,7 +186,7 @@ class ThreadPool:
 
     def _clear_dead_threads(self):
         # Remove any dead threads from our list
-        for t in [t for t in self._threads if not t.isAlive()]:
+        for t in [t for t in self._threads if not t.is_alive()]:
             self._threads.remove(t)
             try:
                 self._pending_shutdowns.popleft()

--- a/cheroot/workers/threadpool.py
+++ b/cheroot/workers/threadpool.py
@@ -186,13 +186,12 @@ class ThreadPool:
 
     def _clear_dead_threads(self):
         # Remove any dead threads from our list
-        for t in self._threads:
-            if not t.isAlive():
-                self._threads.remove(t)
-                try:
-                    self._pending_shutdowns.popleft()
-                except IndexError:
-                    pass
+        for t in [t for t in self._threads if not t.isAlive()]:
+            self._threads.remove(t)
+            try:
+                self._pending_shutdowns.popleft()
+            except IndexError:
+                pass
 
     def grow(self, amount):
         """Spawn new worker threads (not above self.max)."""


### PR DESCRIPTION
❓ **What kind of change does this PR introduce?**
  - [X] 🐞 bug fix
  - [ ] 🐣 feature
  - [ ] 📋 docs update
  - [ ] 📋 tests/coverage improvement
  - [ ] 📋 refactoring
  - [ ] 💥 other

❓ **What is the current behavior?** (You can also link to an open issue here)

This was previously reported as a [CherryPy bug](https://github.com/cherrypy/cherrypy/issues/1206).

📋 **Other information**:

There was a previously submitted fix in the original ticket. I've transplanted the idea behind it into cheroot, and changed the counter to a deque object instead (as I suspect modifying a counter on an object is not an atomic operation).

📋 **Checklist**:

  - [ ] I think the code is well written
  - [ ] I wrote [good commit messages][1]
  - [ ] I have [squashed related commits together][2] after the changes have been approved
  - [ ] Unit tests for the changes exist
  - [ ] Integration tests for the changes exist (if applicable)
  - [ ] I used the same coding conventions as the rest of the project
  - [ ] The new code doesn't generate linter offenses
  - [ ] Documentation reflects the changes
  - [ ] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences

[1]: http://chris.beams.io/posts/git-commit/
[2]: https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cherrypy/cheroot/204)
<!-- Reviewable:end -->
