### PR TITLE
Fixed 'pip install cheroot' on Python 2

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -63,7 +63,8 @@ setup_requires =
 install_requires =
     backports.functools_lru_cache
     six>=1.11.0
-    more_itertools>=2.6
+    more_itertools>=2.6<6; python_version<'3'
+    more_itertools>=2.6; python_version>='3'
 
 [options.extras_require]
 docs =


### PR DESCRIPTION
❓ **What kind of change does this PR introduce?**
  - [x] 🐞 bug fix

❓ **What is the current behavior?** (You can also link to an open issue here)

On Python 2 "pip install cheroot" ends with error:
ERROR: more-itertools requires Python '>=3.4' but the running Python is 2.7.15

The reason: more_itertools package from version 6 does not support Python 2.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cherrypy/cheroot/211)
<!-- Reviewable:end -->
