### PR TITLE
Fix inconsistent name in docstring

### DIFF
--- a/cheroot/server.py
+++ b/cheroot/server.py
@@ -1226,7 +1226,7 @@ class HTTPConnection:
 
         Args:
             server (HTTPServer): web server object receiving this request
-            socket (socket._socketobject): the raw socket object (usually
+            sock (socket._socketobject): the raw socket object (usually
                 TCP) for this connection
             makefile (file): a fileobject class for reading from the socket
         """


### PR DESCRIPTION
❓ **What kind of change does this PR introduce?**
  - [ ] 🐞 bug fix
  - [ ] 🐣 feature
  - [ ] 📋 docs update
  - [ ] 📋 tests/coverage improvement
  - [ ] 📋 refactoring
  - [x] 💥 other

❓ What is the current behavior? (You can also link to an open issue here)

I found inconsistent naming between actual parameter and one written in docstring.

In code:
```py
def __init__(self, server, sock, makefile=MakeFile):
```

In docstring:
```py
"""Initialize HTTPConnection instance.

Args:
    server (HTTPServer): web server object receiving this request
    # HERE
    socket (socket._socketobject): the raw socket object (usually
        TCP) for this connection
    makefile (file): a fileobject class for reading from the socket
"""
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cherrypy/cheroot/215)
<!-- Reviewable:end -->
