### PR TITLE
Return 400 on invalid major-only HTTP version in Request-Line

### DIFF
--- a/cheroot/server.py
+++ b/cheroot/server.py
@@ -788,12 +788,12 @@ class HTTPRequest:
                 )
                 return False
             rp = req_protocol[5:].split(b'.', 1)
-            rp = tuple(map(int, rp))  # Minor.Major must be threat as integers
             if len(rp) != 2:
                 self.simple_response(
                     '400 Bad Request', 'Malformed Request-Line: bad version',
                 )
                 return False
+            rp = tuple(map(int, rp))  # Minor.Major must be threat as integers
             if rp > (1, 1):
                 self.simple_response(
                     '505 HTTP Version Not Supported', 'Cannot fulfill request',

--- a/cheroot/server.py
+++ b/cheroot/server.py
@@ -789,6 +789,11 @@ class HTTPRequest:
                 return False
             rp = req_protocol[5:].split(b'.', 1)
             rp = tuple(map(int, rp))  # Minor.Major must be threat as integers
+            if len(rp) != 2:
+                self.simple_response(
+                    '400 Bad Request', 'Malformed Request-Line: bad version',
+                )
+                return False
             if rp > (1, 1):
                 self.simple_response(
                     '505 HTTP Version Not Supported', 'Cannot fulfill request',

--- a/cheroot/test/test_core.py
+++ b/cheroot/test/test_core.py
@@ -274,6 +274,10 @@ def test_content_length_required(test_client):
             HTTP_BAD_REQUEST, b'Malformed Request-Line: bad protocol',
         ),
         (
+            b'GET / HTTP/1',  # invalid version
+            HTTP_BAD_REQUEST, b'Malformed Request-Line: bad version',
+        ),
+        (
             b'GET / HTTP/2.15',  # invalid ver
             HTTP_VERSION_NOT_SUPPORTED, b'Cannot fulfill request',
         ),


### PR DESCRIPTION
❓ **What kind of change does this PR introduce?**
  - [x] 🐞 bug fix
  - [ ] 🐣 feature
  - [ ] 📋 docs update
  - [ ] 📋 tests/coverage improvement
  - [ ] 📋 refactoring
  - [ ] 💥 other

📋 **What is the related issue number (starting with `#`)**

Fixes #218 

❓ **What is the current behavior?** (You can also link to an open issue here)

cherrypy returns a 500 on some malformed HTTP request due to a missing argument in a format string in `server.read_request_line`.

❓ **What is the new behavior (if this is a feature change)?**

The server now returns a 400.

📋 **Checklist**:

  - [x] I think the code is well written
  - [x] I wrote [good commit messages][1]
  - [x] I have [squashed related commits together][2] after the changes have been approved
  - [x] Unit tests for the changes exist
  - [ ] Integration tests for the changes exist (if applicable)
  - [x] I used the same coding conventions as the rest of the project
  - [x] The new code doesn't generate linter offenses
  - [ ] Documentation reflects the changes
  - [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences

[1]: http://chris.beams.io/posts/git-commit/
[2]: https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cherrypy/cheroot/219)
<!-- Reviewable:end -->
