### PR TITLE
Only require backports.functools_lru_cache for python < 3.3

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,9 @@
+v6.6.0
+======
+
+- Revisit :pr:`85` under :pr:`221`. Now ``backports.unittest_mock``
+  is only required on Python 3.2 and earlier.
+
 v6.5.6
 ======
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,8 +1,9 @@
 v6.6.0
 ======
 
-- Revisit :pr:`85` under :pr:`221`. Now ``backports.unittest_mock``
-  is only required on Python 3.2 and earlier.
+- Revisit :pr:`85` under :pr:`221`. Now
+  ``backports.functools_lru_cache`` is only
+  required on Python 3.2 and earlier.
 
 v6.5.8
 ======

--- a/setup.cfg
+++ b/setup.cfg
@@ -61,7 +61,7 @@ setup_requires =
 
 # These are required in actual runtime:
 install_requires =
-    backports.functools_lru_cache
+    backports.functools_lru_cache ; python_version < '3.3'
     six>=1.11.0
     more_itertools>=2.6
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -61,7 +61,7 @@ setup_requires =
 
 # These are required in actual runtime:
 install_requires =
-    backports.functools_lru_cache ; python_version < '3.3'
+    backports.functools_lru_cache; python_version < '3.3'
     six>=1.11.0
     more_itertools>=2.6
 


### PR DESCRIPTION
❓ **What kind of change does this PR introduce?**
  - [x] 🐞 bug fix
  - [ ] 🐣 feature
  - [ ] 📋 docs update
  - [ ] 📋 tests/coverage improvement
  - [ ] 📋 refactoring
  - [ ] 💥 other

📋 **What is the related issue number (starting with `#`)**

None

❓ **What is the current behavior?** (You can also link to an open issue here)

cheroot requires the `backports.functools_lru_cache` module even for python versions that ship `functools.lru_cache`

❓ **What is the new behavior (if this is a feature change)?**

cheroot only requires `backports.functools_lru_cache` for python < 3.3

📋 **Other information**:



📋 **Checklist**:

  - [x] I think the code is well written
  - [x] I wrote [good commit messages][1]
  - [ ] I have [squashed related commits together][2] after the changes have been approved
  - [-] Unit tests for the changes exist
  - [-] Integration tests for the changes exist (if applicable)
  - [-] I used the same coding conventions as the rest of the project
  - [-] The new code doesn't generate linter offenses
  - [-] Documentation reflects the changes
  - [-] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences

[1]: http://chris.beams.io/posts/git-commit/
[2]: https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cherrypy/cheroot/221)
<!-- Reviewable:end -->
