### PR TITLE
Feature/extract open url once

### DIFF
--- a/cheroot/test/webtest.py
+++ b/cheroot/test/webtest.py
@@ -491,8 +491,6 @@ def openURL(
     a socket.error regardless that they were are subclass of a
     socket.error and therefore not considered for a connection retry.
     """
-    headers = cleanHeaders(headers, method, body, host, port)
-
     # Trying 10 times is simply in case of socket errors.
     # Normal case--it should run once.
     for trial in range(10):
@@ -514,6 +512,8 @@ def _open_url_once(
         body, headers, host, http_conn, method,
         port, protocol, ssl_context, url,
 ):
+    headers = cleanHeaders(headers, method, body, host, port)
+
     # Allow http_conn to be a class or an instance
     if hasattr(http_conn, 'host'):
         conn = http_conn

--- a/cheroot/test/webtest.py
+++ b/cheroot/test/webtest.py
@@ -477,13 +477,16 @@ def shb(response):
     return resp_status_line, h, response.read()
 
 
-def openURL(*args, raise_subcls=(), **kwargs):
+# def openURL(*args, raise_subcls=(), **kwargs):
+# py27 compatible signature:
+def openURL(*args, **kwargs):
     """
     Open a URL, retrying when it fails.
 
     Specify `raise_subcls` (class or tuple of classes) to exclude
     those socket.error subclasses from being suppressed and retried.
     """
+    raise_subcls = kwargs.pop('raise_subcls', ())
     opener = functools.partial(_open_url_once, *args, **kwargs)
 
     def on_exception():

--- a/setup.cfg
+++ b/setup.cfg
@@ -65,6 +65,7 @@ install_requires =
     backports.functools_lru_cache; python_version < '3.3'
     six>=1.11.0
     more_itertools>=2.6
+    jaraco.functools
 
 [options.extras_require]
 docs =


### PR DESCRIPTION
❓ **What kind of change does this PR introduce?**
  - [ ] 🐞 bug fix
  - [X] 🐣 feature
  - [ ] 📋 docs update
  - [ ] 📋 tests/coverage improvement
  - [X] 📋 refactoring
  - [ ] 💥 other

In master, I've separated the concerns of retrying an openURL call from the essential operation of an openURL call. This PR goes a step further and replaces most of the "retry" handling with a proven `retry_call` operation. Re-using this pattern has the advantage of declaring the more abstract goal (of retrying a call) and giving the technique more exposure and re-use.

This change has one backward-incompatible detail - the `raise_subcls` and `ssl_context` can no longer be supplied as a positional parameter, and `None` is no longer a valid value for a degenerate 'raise_subcls` value.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cherrypy/cheroot/224)
<!-- Reviewable:end -->
