### PR TITLE
Restore CircleCI runs on macOS

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,13 +31,11 @@ jobs:
         wait
     - run: pyenv global 2.7.14 3.7.0 3.6.4 3.5.4 3.4.7 pypy3.5-5.10.0
 
-    - run: circleci tests glob **/test/**.py | circleci tests split --split-by=timings | grep -v '__init__.py' | xargs echo >> $TEST_ARGS
-
     - run: pip install tox tox-pyenv
     - checkout
     - run:
         name: Run tests
-        command: tox -e py27,py34,py35,py36,py37,pypy3 -- -p no:sugar $TEST_ARGS
+        command: tox -e py27,py34,py35,py36,py37,pypy3 -- -p no:sugar $(circleci tests glob **/test/**.py | circleci tests split --split-by=timings | grep -v '__init__.py')
         # Environment variables for py-cryptography library
         environment:
           LDFLAGS: "-L/usr/local/opt/openssl/lib"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,11 +31,13 @@ jobs:
         wait
     - run: pyenv global 2.7.14 3.7.0 3.6.4 3.5.4 3.4.7 pypy3.5-5.10.0
 
+    - run: circleci tests glob **/test/**.py | circleci tests split --split-by=timings | grep -v '__init__.py' | xargs echo >> $TEST_ARGS
+
     - run: pip install tox tox-pyenv
     - checkout
     - run:
         name: Run tests
-        command: tox -e py27-circleci,py34-circleci,py35-circleci,py36-circleci,py37-circleci,pypy3-circleci -- -p no:sugar
+        command: tox -e py27,py34,py35,py36,py37,pypy3 -- -p no:sugar $TEST_ARGS
         # Environment variables for py-cryptography library
         environment:
           LDFLAGS: "-L/usr/local/opt/openssl/lib"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,7 +51,7 @@ jobs:
     steps:
     - checkout
     - run: pip install tox
-    - run: tox -e py27,py34,py35,py36,py37
+    - run: tox -e py27,py34,py35,py36,py37 -- $(circleci tests glob **/test/**.py | circleci tests split --split-by=timings | grep -v '__init__.py')
 
 workflows:
   version: 2

--- a/tox.ini
+++ b/tox.ini
@@ -5,11 +5,8 @@ minversion = 3.13.2
 [testenv]
 deps =
     setuptools>=31.0.1
-whitelist_externals =
-    circleci: circleci
 commands =
-    !circleci: pytest --testmon-off {posargs}
-    circleci: circleci tests glob **/test/**.py | circleci tests split --split-by=timings | grep -v '__init__.py' | xargs pytest --testmon-off {posargs}
+    pytest --testmon-off {posargs}
     codecov -f coverage.xml -X gcov
 usedevelop = True
 extras = testing


### PR DESCRIPTION
As reported in #239, this change restores the CircleCI builds. They're still noisy and they still batch all of their runs, and I'm not even sure the `circleci` command is doing anything useful, but at least the tests are running again.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cherrypy/cheroot/240)
<!-- Reviewable:end -->
