### PR TITLE
Add a test that demonstrates an OverflowError

### DIFF
--- a/cheroot/test/test_core.py
+++ b/cheroot/test/test_core.py
@@ -81,7 +81,6 @@ def testing_server(wsgi_server_client):
     """Attach a WSGI app to the given server and preconfigure it."""
     wsgi_server = wsgi_server_client.server_instance
     wsgi_server.wsgi_app = HelloController()
-    wsgi_server.max_request_body_size = 30000000
     wsgi_server.server_client = wsgi_server_client
     return wsgi_server
 
@@ -404,7 +403,6 @@ def testing_server_close(wsgi_server_client):
     """Attach a WSGI app to the given server and preconfigure it."""
     wsgi_server = wsgi_server_client.server_instance
     wsgi_server.wsgi_app = CloseController()
-    wsgi_server.max_request_body_size = 30000000
     wsgi_server.server_client = wsgi_server_client
     return wsgi_server
 

--- a/cheroot/test/test_core.py
+++ b/cheroot/test/test_core.py
@@ -82,6 +82,7 @@ def testing_server(wsgi_server_client):
     """Attach a WSGI app to the given server and preconfigure it."""
     wsgi_server = wsgi_server_client.server_instance
     wsgi_server.wsgi_app = HelloController()
+    wsgi_server.max_request_body_size = 30000000
     wsgi_server.server_client = wsgi_server_client
     return wsgi_server
 
@@ -422,6 +423,7 @@ def testing_server_close(wsgi_server_client):
     """Attach a WSGI app to the given server and preconfigure it."""
     wsgi_server = wsgi_server_client.server_instance
     wsgi_server.wsgi_app = CloseController()
+    wsgi_server.max_request_body_size = 30000000
     wsgi_server.server_client = wsgi_server_client
     return wsgi_server
 


### PR DESCRIPTION
❓ **What kind of change does this PR introduce?**
  - [ ] 🐞 bug fix
  - [ ] 🐣 feature
  - [ ] 📋 docs update
  - [x] 📋 tests/coverage improvement
  - [ ] 📋 refactoring
  - [ ] 💥 other

📋 **What is the related issue number (starting with `#`)**

#106

❓ **What is the current behavior?** (You can also link to an open issue here)
The current test server fixture in `test_core.py` set a reasonable default for `max_request_body_size`. There doesn't exist tests that check for behavior as a result of malicious Content-Length headers.


❓ **What is the new behavior (if this is a feature change)?**
I have removed the setting of `max_request_body_size` in the test server fixtures to reflect the default behavior of servers. I have added a test case for requests with large Content-Length headers that is marked as xfail.


📋 **Other information**:



📋 **Checklist**:

  - [ ] I think the code is well written
  - [ ] I wrote [good commit messages][1]
  - [ ] I have [squashed related commits together][2] after the changes have been approved
  - [ ] Unit tests for the changes exist
  - [ ] Integration tests for the changes exist (if applicable)
  - [ ] I used the same coding conventions as the rest of the project
  - [ ] The new code doesn't generate linter offenses
  - [ ] Documentation reflects the changes
  - [ ] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences

[1]: http://chris.beams.io/posts/git-commit/
[2]: https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cherrypy/cheroot/247)
<!-- Reviewable:end -->
