### PR TITLE
Fix parsing of the `--bind` option for abstract UNIX sockets

### DIFF
--- a/cheroot/cli.py
+++ b/cheroot/cli.py
@@ -134,6 +134,7 @@ def parse_wsgi_bind_location(bind_addr_string):
     # with value: "<value>" and port: None
     if bind_addr_string.startswith('@'):
         return AbstractSocket(bind_addr_string[1:])
+
     # try and match for an IP/hostname and port
     match = six.moves.urllib.parse.urlparse('//{}'.format(bind_addr_string))
     try:
@@ -143,6 +144,7 @@ def parse_wsgi_bind_location(bind_addr_string):
             return TCPSocket(addr, port)
     except ValueError:
         pass
+
     # else, assume a UNIX socket path
     return UnixSocket(path=bind_addr_string)
 

--- a/cheroot/test/test_cli.py
+++ b/cheroot/test/test_cli.py
@@ -74,7 +74,6 @@ def test_Aplication_resolve(
         full_path = None
         for p in pkg_name.split('.'):
             full_path = p if full_path is None else '.'.join((full_path, p))
-            print('Full path is {}'.format(full_path))
             monkeypatch.setitem(sys.modules, full_path, mocked_app)
     else:
         monkeypatch.setitem(sys.modules, pkg_name, mocked_app)

--- a/cheroot/test/test_cli.py
+++ b/cheroot/test/test_cli.py
@@ -3,18 +3,23 @@ from cheroot.cli import (
     parse_wsgi_bind_addr
 )
 
+
 def test_parse_wsgi_bind_location_for_tcpip():
     assert parse_wsgi_bind_addr('192.168.1.1:80') == ('192.168.1.1', 80)
     assert parse_wsgi_bind_addr('[::1]:8000') == ('::1', 8000)
 
+
 def test_parse_wsgi_bind_location_for_unix_socket():
     assert parse_wsgi_bind_addr('/tmp/cheroot.sock') == '/tmp/cheroot.sock'
+
 
 def test_parse_wsgi_bind_addr_for_abstract_unix_socket():
     assert parse_wsgi_bind_addr('@cheroot') == '\0cheroot'
 
+
 def test_Aplication_resolve():
     import sys
+
     class WSGIAppMock:
         def application(self):
             pass

--- a/cheroot/test/test_cli.py
+++ b/cheroot/test/test_cli.py
@@ -14,68 +14,77 @@ from cheroot.cli import (
 
 @pytest.mark.parametrize(
     'raw_bind_addr, expected_bind_addr', (
+        # tcp/ip
         ('192.168.1.1:80', ('192.168.1.1', 80)),
+        # ipv6 ips has to be enclosed in brakets when specified in url form
         ('[::1]:8000', ('::1', 8000)),
+        ('localhost:5000', ('localhost', 5000)),
+        # this is a valid input, but foo gets discarted
+        ('foo@bar:5000', ('bar', 5000)),
+        ('foo', ('foo', None)),
+        ('123456789', ('123456789', None)),
+        # unix sockets
+        ('/tmp/cheroot.sock', '/tmp/cheroot.sock'),
+        ('/tmp/some-random-file-name', '/tmp/some-random-file-name'),
+        # abstract sockets
+        ('@cheroot', '\0cheroot'),
     ),
 )
-def test_parse_wsgi_bind_addr_for_tcpip(raw_bind_addr, expected_bind_addr):
-    """Check the parsing of the --bind option for TCP/IP addresses."""
+def test_parse_wsgi_bind_addr(raw_bind_addr, expected_bind_addr):
+    """Check the parsing of the --bind option.
+
+    Verify some of the supported addresses and the excpected return value.
+    """
     assert parse_wsgi_bind_addr(raw_bind_addr) == expected_bind_addr
 
 
-def test_parse_wsgi_bind_addr_for_unix_socket():
-    """Check the parsing of the --bind option for UNIX Sockets."""
-    assert parse_wsgi_bind_addr('/tmp/cheroot.sock') == '/tmp/cheroot.sock'
+@pytest.fixture
+def wsgi_app(monkeypatch):
+    """Return a WSGI app stub."""
+    class WSGIAppMock:
+        """Mock of a wsgi module."""
 
+        def application(self):
+            """Empty application method.
 
-def test_parse_wsgi_bind_addr_for_abstract_unix_socket():
-    """Check the parsing of the --bind option for Abstract UNIX Sockets."""
-    assert parse_wsgi_bind_addr('@cheroot') == '\0cheroot'
+            Default method to be called when no specific callable
+            is defined in the wsgi application identifier.
 
+            It has an empty body because we are expecting to verify that
+            the same method is return no the actual execution of it.
+            """
 
-class WSGIAppMock:
-    """Mock of a wsgi module."""
+        def main(self):
+            """Empty custom method (callable) inside the mocked WSGI app.
 
-    def application(self):
-        """Empty application method.
-
-        Default method to be called when no specific callable
-        is defined in the wsgi application identifier.
-
-        It has an empty body because we are expecting to verify that
-        the same method is return no the actual execution of it.
-        """
-
-    def main(self):
-        """Empty custom method (callable) inside the mocked WSGI app.
-
-        It has an empty body because we are expecting to verify that
-        the same method is return no the actual execution of it.
-        """
-
-
-@pytest.mark.parametrize(
-    'wsgi_app_spec, pkg_name, app_method, mocked_app', (
-        ('mypkg.wsgi', 'mypkg.wsgi', 'application', WSGIAppMock()),
-        ('mypkg.wsgi:application', 'mypkg.wsgi', 'application', WSGIAppMock()),
-        ('mypkg.wsgi:main', 'mypkg.wsgi', 'main', WSGIAppMock()),
-    ),
-)
-def test_Aplication_resolve(
-    monkeypatch,
-    wsgi_app_spec, pkg_name, app_method, mocked_app,
-):
-    """Check the wsgi application name conversion."""
+            It has an empty body because we are expecting to verify that
+            the same method is return no the actual execution of it.
+            """
+    app = WSGIAppMock()
+    # patch sys.modules, to include the an instance of WSGIAppMock
+    # under a specific namespace
     if six.PY2:
         # python2 requires the previous namespaces to be part of sys.modules
         #   (e.g. for 'a.b.c' we need to insert 'a', 'a.b' and 'a.b.c')
         # otherwise it fails, we're setting the same instance on each level,
         # we don't really care about those, just the last one.
-        full_path = None
-        for p in pkg_name.split('.'):
-            full_path = p if full_path is None else '.'.join((full_path, p))
-            monkeypatch.setitem(sys.modules, full_path, mocked_app)
+        monkeypatch.setitem(sys.modules, 'mypkg', app)
+    monkeypatch.setitem(sys.modules, 'mypkg.wsgi', app)
+    return app
+
+
+@pytest.mark.parametrize(
+    'app_name, app_method', (
+        (None, 'application',),
+        ('application', 'application',),
+        ('main', 'main',),
+    ),
+)
+def test_Aplication_resolve(app_name, app_method, wsgi_app):
+    """Check the wsgi application name conversion."""
+    if app_name is None:
+        wsgi_app_spec = 'mypkg.wsgi'
     else:
-        monkeypatch.setitem(sys.modules, pkg_name, mocked_app)
-    expected_app = getattr(mocked_app, app_method)
+        wsgi_app_spec = 'mypkg.wsgi:{}'.format(app_name)
+    expected_app = getattr(wsgi_app, app_method)
     assert Application.resolve(wsgi_app_spec).wsgi_app == expected_app

--- a/cheroot/test/test_cli.py
+++ b/cheroot/test/test_cli.py
@@ -1,0 +1,32 @@
+from cheroot.cli import (
+    Application,
+    parse_wsgi_bind_addr
+)
+
+def test_parse_wsgi_bind_location_for_tcpip():
+    assert parse_wsgi_bind_addr('192.168.1.1:80') == ('192.168.1.1', 80)
+    assert parse_wsgi_bind_addr('[::1]:8000') == ('::1', 8000)
+
+def test_parse_wsgi_bind_location_for_unix_socket():
+    assert parse_wsgi_bind_addr('/tmp/cheroot.sock') == '/tmp/cheroot.sock'
+
+def test_parse_wsgi_bind_addr_for_abstract_unix_socket():
+    assert parse_wsgi_bind_addr('@cheroot') == '\0cheroot'
+
+def test_Aplication_resolve():
+    import sys
+    class WSGIAppMock:
+        def application(self):
+            pass
+
+        def main(self):
+            pass
+    try:
+        wsgi_app_mock = WSGIAppMock()
+        sys.modules['mypkg.wsgi'] = wsgi_app_mock
+        app = Application.resolve('mypkg.wsgi')
+        assert app.wsgi_app == wsgi_app_mock.application
+        app = Application.resolve('mypkg.wsgi:main')
+        assert app.wsgi_app == wsgi_app_mock.main
+    finally:
+        del sys.modules['mypkg.wsgi']

--- a/cheroot/test/test_core.py
+++ b/cheroot/test/test_core.py
@@ -282,8 +282,8 @@ def test_content_length_required(test_client):
 def test_large_request(test_client_with_defaults):
     """Test GET query with maliciously large Content-Length."""
     # If the server's max_request_body_size is not set (i.e. is set to 0)
-    # then this will result in an `OverflowError: Python int too large to convert to C ssize_t`
-    # in the server.
+    # then this will result in an `OverflowError: Python int too large to
+    # convert to C `ssize_t` in the server.
     # We expect that this should instead return that the request is too
     # large.
     c = test_client_with_defaults.get_connection()


### PR DESCRIPTION
❓ **What kind of change does this PR introduce?**
  - [X] 🐞 bug fix
  - [ ] 🐣 feature
  - [ ] 📋 docs update
  - [X] 📋 tests/coverage improvement
  - [ ] 📋 refactoring
  - [ ] 💥 other

📋 **What is the related issue number (starting with `#`)**

It wasn't reported.

❓ **What is the current behavior?** (You can also link to an open issue here)

The `--bind` option wasn't properly parsed for abstract unix socket.
Something like `cheroot --bind @mysocket` would immediately fail with something like:
```python-traceback
$ python -m cheroot 'myapp.wsgi' --bind @MYSOCK
Keyboard Interrupt: shutting down
Traceback (most recent call last):
  File "/nix/store/nzb7x6kij7mk07m88jwv8m1hhyjzjmb1-python3-3.8.0/lib/python3.8/runpy.py", line 192, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/nix/store/nzb7x6kij7mk07m88jwv8m1hhyjzjmb1-python3-3.8.0/lib/python3.8/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/nix/store/ij4qzqw81lnas4f59g05l3amkh928y4l-python3.8-cheroot-8.2.1/lib/python3.8/site-packages/cheroot/__main__.py", line 6, in <module>
    main()
  File "/nix/store/ij4qzqw81lnas4f59g05l3amkh928y4l-python3.8-cheroot-8.2.1/lib/python3.8/site-packages/cheroot/cli.py", line 234, in main
    raw_args._wsgi_app.server(raw_args).safe_start()
  File "/nix/store/ij4qzqw81lnas4f59g05l3amkh928y4l-python3.8-cheroot-8.2.1/lib/python3.8/site-packages/cheroot/server.py", line 1686, in safe_start
    self.start()
  File "/nix/store/ij4qzqw81lnas4f59g05l3amkh928y4l-python3.8-cheroot-8.2.1/lib/python3.8/site-packages/cheroot/server.py", line 1795, in start
    self.prepare()
  File "/nix/store/ij4qzqw81lnas4f59g05l3amkh928y4l-python3.8-cheroot-8.2.1/lib/python3.8/site-packages/cheroot/server.py", line 1728, in prepare
    info = socket.getaddrinfo(
  File "/nix/store/nzb7x6kij7mk07m88jwv8m1hhyjzjmb1-python3-3.8.0/lib/python3.8/socket.py", line 914, in getaddrinfo
    for res in _socket.getaddrinfo(host, port, family, type, proto, flags):
OSError: [Errno 16] Device or resource busy
```
Because the server would try to connect using TCP/IP at `MYSOCK` port `None`, given the faulty parsing of the CLI.

❓ **What is the new behavior (if this is a feature change)?**

The `--bind` option now works for abstract UNIX sockets.

📋 **Other information**:


📋 **Checklist**:

  - [X] I think the code is well written
  - [ ] I wrote [good commit messages][1]
  - [ ] I have [squashed related commits together][2] after the changes have been approved
  - [X] Unit tests for the changes exist
  - [ ] Integration tests for the changes exist (if applicable)
  - [x] I used the same coding conventions as the rest of the project
  - [x] The new code doesn't generate linter offenses
  - [ ] Documentation reflects the changes
  - [X] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences

[1]: http://chris.beams.io/posts/git-commit/
[2]: https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cherrypy/cheroot/248)
<!-- Reviewable:end -->
