### PR TITLE
Fix flake8 issue WPS336 (explicit str concat)

### DIFF
--- a/cheroot/server.py
+++ b/cheroot/server.py
@@ -1041,8 +1041,8 @@ class HTTPRequest:
             # we don't want. See
             # https://github.com/cherrypy/cherrypy/issues/951
             msg = '{} {}'.format(self.server.protocol,
-                                 '100 Continue\r\n\r\n') \
-                                 .encode('ascii')
+                '100 Continue\r\n\r\n') \
+                .encode('ascii')
             try:
                 self.conn.wfile.write(msg)
             except socket.error as ex:

--- a/cheroot/server.py
+++ b/cheroot/server.py
@@ -1038,10 +1038,8 @@ class HTTPRequest:
             # Don't use simple_response here, because it emits headers
             # we don't want. See
             # https://github.com/cherrypy/cherrypy/issues/951
-            msg = b'{} {}'.format(
-                                  self.server.protocol.encode('ascii'),
-                                  b'100 Continue\r\n\r\n',
-            )
+            msg = '{} {}'.format(self.server.protocol, '100 Continue\r\n\r\n')
+                             .encode('ascii')
             try:
                 self.conn.wfile.write(msg)
             except socket.error as ex:

--- a/cheroot/server.py
+++ b/cheroot/server.py
@@ -823,7 +823,9 @@ class HTTPRequest:
 
             # `urlsplit()` above parses "example.com:3128" as path part of URI.
             # this is a workaround, which makes it detect netloc correctly
-            uri_split = urllib.parse.urlsplit('//{}'.format(uri).encode('ascii'))
+            uri_split = urllib.parse.urlsplit( \
+                                    '//{}'.format(uri) \
+                                    .encode('ascii'))
             _scheme, _authority, _path, _qs, _fragment = uri_split
             _port = EMPTY
             try:
@@ -1038,7 +1040,9 @@ class HTTPRequest:
             # Don't use simple_response here, because it emits headers
             # we don't want. See
             # https://github.com/cherrypy/cherrypy/issues/951
-            msg = '{} {}'.format(self.server.protocol, '100 Continue\r\n\r\n').encode('ascii')
+            msg = '{} {}'.format(self.server.protocol,
+                                 '100 Continue\r\n\r\n') \
+                                 .encode('ascii')
             try:
                 self.conn.wfile.write(msg)
             except socket.error as ex:

--- a/cheroot/server.py
+++ b/cheroot/server.py
@@ -1038,8 +1038,10 @@ class HTTPRequest:
             # Don't use simple_response here, because it emits headers
             # we don't want. See
             # https://github.com/cherrypy/cherrypy/issues/951
-            msg = b''.join([self.server.protocol.encode('ascii'),
-                           b' 100 Contunue\r\n\r\n'])
+            msg = b'{} {}'.format(
+                                  self.server.protocol.encode('ascii'),
+                                  b'100 Continue\r\n\r\n',
+            )
             try:
                 self.conn.wfile.write(msg)
             except socket.error as ex:

--- a/cheroot/server.py
+++ b/cheroot/server.py
@@ -823,8 +823,8 @@ class HTTPRequest:
 
             # `urlsplit()` above parses "example.com:3128" as path part of URI.
             # this is a workaround, which makes it detect netloc correctly
-            uri_split = urllib.parse.urlsplit( \
-                                    '//{}'.format(uri) \
+            uri_split = urllib.parse.urlsplit(
+                                    '//{}'.format(uri)
                                     .encode('ascii'))
             _scheme, _authority, _path, _qs, _fragment = uri_split
             _port = EMPTY

--- a/cheroot/server.py
+++ b/cheroot/server.py
@@ -156,7 +156,7 @@ EMPTY = b''
 ASTERISK = b'*'
 FORWARD_SLASH = b'/'
 QUOTED_SLASH = b'%2F'
-QUOTED_SLASH_REGEX = re.compile(b'(?i)' + QUOTED_SLASH)
+QUOTED_SLASH_REGEX = re.compile(b('(?i)%s' % (QUOTED_SLASH)))
 
 
 comma_separated_headers = [
@@ -467,7 +467,7 @@ class ChunkedRFile:
             chunk_size = line.pop(0)
             chunk_size = int(chunk_size, 16)
         except ValueError:
-            raise ValueError('Bad chunked transfer size: ' + repr(chunk_size))
+            raise ValueError('Bad chunked transfer size: %s' % (repr(chunk_size)))
 
         if chunk_size <= 0:
             self.closed = True
@@ -822,7 +822,7 @@ class HTTPRequest:
 
             # `urlsplit()` above parses "example.com:3128" as path part of URI.
             # this is a workaround, which makes it detect netloc correctly
-            uri_split = urllib.parse.urlsplit(b'//' + uri)
+            uri_split = urllib.parse.urlsplit(b'//%s' % (uri))
             _scheme, _authority, _path, _qs, _fragment = uri_split
             _port = EMPTY
             try:
@@ -1037,8 +1037,7 @@ class HTTPRequest:
             # Don't use simple_response here, because it emits headers
             # we don't want. See
             # https://github.com/cherrypy/cherrypy/issues/951
-            msg = self.server.protocol.encode('ascii')
-            msg += b' 100 Continue\r\n\r\n'
+            msg = b''.join([self.server.protocol.encode('ascii'), b' 100 Contunue\r\n\r\n'])
             try:
                 self.conn.wfile.write(msg)
             except socket.error as ex:
@@ -1499,7 +1498,7 @@ class HTTPServer:
     timeout = 10
     """The timeout in seconds for accepted connections (default 10)."""
 
-    version = 'Cheroot/' + __version__
+    version = 'Cheroot/%s' % (__version__)
     """A version string for the HTTPServer."""
 
     software = None
@@ -1805,7 +1804,7 @@ class HTTPServer:
             traceback (bool): add traceback to output or not
         """
         # Override this in subclasses as desired
-        sys.stderr.write(msg + '\n')
+        sys.stderr.write('%s\n' % (msg))
         sys.stderr.flush()
         if traceback:
             tblines = traceback_.format_exc()

--- a/cheroot/server.py
+++ b/cheroot/server.py
@@ -156,7 +156,7 @@ EMPTY = b''
 ASTERISK = b'*'
 FORWARD_SLASH = b'/'
 QUOTED_SLASH = b'%2F'
-QUOTED_SLASH_REGEX = re.compile(b''.join([b'(?i)', QUOTED_SLASH]))
+QUOTED_SLASH_REGEX = re.compile(b''.join((b'(?i)', QUOTED_SLASH)))
 
 
 comma_separated_headers = [
@@ -467,8 +467,10 @@ class ChunkedRFile:
             chunk_size = line.pop(0)
             chunk_size = int(chunk_size, 16)
         except ValueError:
-            raise ValueError('Bad chunked transfer size: {}'
-                             .format(repr(chunk_size)))
+            raise ValueError(
+                'Bad chunked transfer size: {chunk_size!r}'.
+                format(chunk_size=chunk_size),
+            )
 
         if chunk_size <= 0:
             self.closed = True
@@ -823,9 +825,7 @@ class HTTPRequest:
 
             # `urlsplit()` above parses "example.com:3128" as path part of URI.
             # this is a workaround, which makes it detect netloc correctly
-            uri_split = urllib.parse.urlsplit(
-                '//{}'.format(uri)
-                .encode('ascii'))
+            uri_split = urllib.parse.urlsplit(b''.join((b'//', uri)))
             _scheme, _authority, _path, _qs, _fragment = uri_split
             _port = EMPTY
             try:
@@ -1040,9 +1040,10 @@ class HTTPRequest:
             # Don't use simple_response here, because it emits headers
             # we don't want. See
             # https://github.com/cherrypy/cherrypy/issues/951
-            msg = '{} {}'.format(self.server.protocol,
-                '100 Continue\r\n\r\n') \
-                .encode('ascii')
+            msg = b''.join((
+                self.server.protocol.encode('ascii'), SPACE, b'100 Continue',
+                CRLF, CRLF,
+            ))
             try:
                 self.conn.wfile.write(msg)
             except socket.error as ex:
@@ -1503,7 +1504,7 @@ class HTTPServer:
     timeout = 10
     """The timeout in seconds for accepted connections (default 10)."""
 
-    version = 'Cheroot/{}'.format(__version__)
+    version = 'Cheroot/{version!s}'.format(version=__version__)
     """A version string for the HTTPServer."""
 
     software = None
@@ -1809,7 +1810,7 @@ class HTTPServer:
             traceback (bool): add traceback to output or not
         """
         # Override this in subclasses as desired
-        sys.stderr.write('{}\n'.format(msg))
+        sys.stderr.write('{msg!s}\n'.format(msg=msg))
         sys.stderr.flush()
         if traceback:
             tblines = traceback_.format_exc()

--- a/cheroot/server.py
+++ b/cheroot/server.py
@@ -823,7 +823,7 @@ class HTTPRequest:
 
             # `urlsplit()` above parses "example.com:3128" as path part of URI.
             # this is a workaround, which makes it detect netloc correctly
-            uri_split = urllib.parse.urlsplit(b'//%s' % (uri))
+            uri_split = urllib.parse.urlsplit('//{}'.format(uri).encode('ascii'))
             _scheme, _authority, _path, _qs, _fragment = uri_split
             _port = EMPTY
             try:
@@ -1038,8 +1038,7 @@ class HTTPRequest:
             # Don't use simple_response here, because it emits headers
             # we don't want. See
             # https://github.com/cherrypy/cherrypy/issues/951
-            msg = '{} {}'.format(self.server.protocol, '100 Continue\r\n\r\n')
-                             .encode('ascii')
+            msg = '{} {}'.format(self.server.protocol, '100 Continue\r\n\r\n').encode('ascii')
             try:
                 self.conn.wfile.write(msg)
             except socket.error as ex:

--- a/cheroot/server.py
+++ b/cheroot/server.py
@@ -156,7 +156,7 @@ EMPTY = b''
 ASTERISK = b'*'
 FORWARD_SLASH = b'/'
 QUOTED_SLASH = b'%2F'
-QUOTED_SLASH_REGEX = re.compile(b'(?i)%s' % (QUOTED_SLASH))
+QUOTED_SLASH_REGEX = re.compile(b''.join([b'(?i)', QUOTED_SLASH]))
 
 
 comma_separated_headers = [
@@ -467,8 +467,8 @@ class ChunkedRFile:
             chunk_size = line.pop(0)
             chunk_size = int(chunk_size, 16)
         except ValueError:
-            raise ValueError('Bad chunked transfer size: %s'
-                             % (repr(chunk_size)))
+            raise ValueError('Bad chunked transfer size: {}'
+                             .format(repr(chunk_size)))
 
         if chunk_size <= 0:
             self.closed = True
@@ -1500,7 +1500,7 @@ class HTTPServer:
     timeout = 10
     """The timeout in seconds for accepted connections (default 10)."""
 
-    version = 'Cheroot/%s' % (__version__)
+    version = 'Cheroot/{}'.format(__version__)
     """A version string for the HTTPServer."""
 
     software = None
@@ -1806,7 +1806,7 @@ class HTTPServer:
             traceback (bool): add traceback to output or not
         """
         # Override this in subclasses as desired
-        sys.stderr.write('%s\n' % (msg))
+        sys.stderr.write('{}\n'.format(msg))
         sys.stderr.flush()
         if traceback:
             tblines = traceback_.format_exc()

--- a/cheroot/server.py
+++ b/cheroot/server.py
@@ -156,7 +156,7 @@ EMPTY = b''
 ASTERISK = b'*'
 FORWARD_SLASH = b'/'
 QUOTED_SLASH = b'%2F'
-QUOTED_SLASH_REGEX = re.compile(b('(?i)%s' % (QUOTED_SLASH)))
+QUOTED_SLASH_REGEX = re.compile(b'(?i)%s' % (QUOTED_SLASH))
 
 
 comma_separated_headers = [

--- a/cheroot/server.py
+++ b/cheroot/server.py
@@ -825,7 +825,7 @@ class HTTPRequest:
             # this is a workaround, which makes it detect netloc correctly
             uri_split = urllib.parse.urlsplit(
                         '//{}'.format(uri)
-                            .encode('ascii'))
+                        .encode('ascii'))
             _scheme, _authority, _path, _qs, _fragment = uri_split
             _port = EMPTY
             try:

--- a/cheroot/server.py
+++ b/cheroot/server.py
@@ -468,7 +468,7 @@ class ChunkedRFile:
             chunk_size = int(chunk_size, 16)
         except ValueError:
             raise ValueError('Bad chunked transfer size: %s'
-                % (repr(chunk_size)))
+                             % (repr(chunk_size)))
 
         if chunk_size <= 0:
             self.closed = True
@@ -1039,7 +1039,7 @@ class HTTPRequest:
             # we don't want. See
             # https://github.com/cherrypy/cherrypy/issues/951
             msg = b''.join([self.server.protocol.encode('ascii'),
-                 b' 100 Contunue\r\n\r\n'])
+                           b' 100 Contunue\r\n\r\n'])
             try:
                 self.conn.wfile.write(msg)
             except socket.error as ex:

--- a/cheroot/server.py
+++ b/cheroot/server.py
@@ -824,8 +824,8 @@ class HTTPRequest:
             # `urlsplit()` above parses "example.com:3128" as path part of URI.
             # this is a workaround, which makes it detect netloc correctly
             uri_split = urllib.parse.urlsplit(
-                        '//{}'.format(uri)
-                        .encode('ascii'))
+                '//{}'.format(uri)
+                .encode('ascii'))
             _scheme, _authority, _path, _qs, _fragment = uri_split
             _port = EMPTY
             try:

--- a/cheroot/server.py
+++ b/cheroot/server.py
@@ -824,8 +824,8 @@ class HTTPRequest:
             # `urlsplit()` above parses "example.com:3128" as path part of URI.
             # this is a workaround, which makes it detect netloc correctly
             uri_split = urllib.parse.urlsplit(
-                                    '//{}'.format(uri)
-                                    .encode('ascii'))
+                            '//{}'.format(uri)
+                            .encode('ascii'))
             _scheme, _authority, _path, _qs, _fragment = uri_split
             _port = EMPTY
             try:

--- a/cheroot/server.py
+++ b/cheroot/server.py
@@ -467,7 +467,8 @@ class ChunkedRFile:
             chunk_size = line.pop(0)
             chunk_size = int(chunk_size, 16)
         except ValueError:
-            raise ValueError('Bad chunked transfer size: %s' % (repr(chunk_size)))
+            raise ValueError('Bad chunked transfer size: %s'
+                % (repr(chunk_size)))
 
         if chunk_size <= 0:
             self.closed = True
@@ -1037,7 +1038,8 @@ class HTTPRequest:
             # Don't use simple_response here, because it emits headers
             # we don't want. See
             # https://github.com/cherrypy/cherrypy/issues/951
-            msg = b''.join([self.server.protocol.encode('ascii'), b' 100 Contunue\r\n\r\n'])
+            msg = b''.join([self.server.protocol.encode('ascii'),
+                 b' 100 Contunue\r\n\r\n'])
             try:
                 self.conn.wfile.write(msg)
             except socket.error as ex:

--- a/cheroot/server.py
+++ b/cheroot/server.py
@@ -824,7 +824,7 @@ class HTTPRequest:
             # `urlsplit()` above parses "example.com:3128" as path part of URI.
             # this is a workaround, which makes it detect netloc correctly
             uri_split = urllib.parse.urlsplit(
-                            '//{}'.format(uri)
+                        '//{}'.format(uri)
                             .encode('ascii'))
             _scheme, _authority, _path, _qs, _fragment = uri_split
             _port = EMPTY

--- a/cheroot/test/test_conn.py
+++ b/cheroot/test/test_conn.py
@@ -838,7 +838,7 @@ def test_Chunked_Encoding(test_client):
 
     # Try a chunked request that exceeds server.max_request_body_size.
     # Note that the delimiters and trailer are included.
-    body = '{}{}{}'.format('3e3\r\n', 'x' * 995, '\r\n0\r\n\r\n')
+    body = '{}{}{}'.format('3e3\r\n', 'x' * 995, '\r\n0\r\n\r\n') \
                        .encode('ascii')
     conn.putrequest('POST', '/upload', skip_host=True)
     conn.putheader('Host', conn.host)

--- a/cheroot/test/test_conn.py
+++ b/cheroot/test/test_conn.py
@@ -838,7 +838,8 @@ def test_Chunked_Encoding(test_client):
 
     # Try a chunked request that exceeds server.max_request_body_size.
     # Note that the delimiters and trailer are included.
-    body = b''.join([b'3e3\r\n', (b'x' * 995), b'\r\n0\r\n\r\n'])
+    body = '{}{}{}'.format('3e3\r\n', 'x' * 995, '\r\n0\r\n\r\n')
+                       .encode('ascii')
     conn.putrequest('POST', '/upload', skip_host=True)
     conn.putheader('Host', conn.host)
     conn.putheader('Transfer-Encoding', 'chunked')
@@ -971,8 +972,8 @@ def test_No_CRLF(test_client, invalid_terminator):
     # Initialize a persistent HTTP connection
     conn = test_client.get_connection()
 
-    # (b'%s' % b'') is not supported in Python 3.4, so just use +
-    conn.send(b''.join([b'GET /hello HTTP/1.1', invalid_terminator]))
+    conn.send('GET /hello HTTP/1.1{}'.format(invalid_terminator)
+            .encode('ascii'))
     response = conn.response_class(conn.sock, method='GET')
     response.begin()
     actual_resp_body = response.read()

--- a/cheroot/test/test_conn.py
+++ b/cheroot/test/test_conn.py
@@ -839,7 +839,7 @@ def test_Chunked_Encoding(test_client):
     # Try a chunked request that exceeds server.max_request_body_size.
     # Note that the delimiters and trailer are included.
     body = '{}{}{}'.format('3e3\r\n', 'x' * 995, '\r\n0\r\n\r\n') \
-                       .encode('ascii')
+               .encode('ascii')
     conn.putrequest('POST', '/upload', skip_host=True)
     conn.putheader('Host', conn.host)
     conn.putheader('Transfer-Encoding', 'chunked')
@@ -973,7 +973,7 @@ def test_No_CRLF(test_client, invalid_terminator):
     conn = test_client.get_connection()
 
     conn.send('GET /hello HTTP/1.1{}'.format(invalid_terminator)
-            .encode('ascii'))
+                                     .encode('ascii'))
     response = conn.response_class(conn.sock, method='GET')
     response.begin()
     actual_resp_body = response.read()

--- a/cheroot/test/test_conn.py
+++ b/cheroot/test/test_conn.py
@@ -838,7 +838,7 @@ def test_Chunked_Encoding(test_client):
 
     # Try a chunked request that exceeds server.max_request_body_size.
     # Note that the delimiters and trailer are included.
-    body = b'3e3\r\n' + (b'x' * 995) + b'\r\n0\r\n\r\n'
+    body = b''.join([b'3e3\r\n', (b'x' * 995), b'\r\n0\r\n\r\n'])
     conn.putrequest('POST', '/upload', skip_host=True)
     conn.putheader('Host', conn.host)
     conn.putheader('Transfer-Encoding', 'chunked')
@@ -972,7 +972,7 @@ def test_No_CRLF(test_client, invalid_terminator):
     conn = test_client.get_connection()
 
     # (b'%s' % b'') is not supported in Python 3.4, so just use +
-    conn.send(b'GET /hello HTTP/1.1' + invalid_terminator)
+    conn.send(b''.join([b'GET /hello HTTP/1.1', invalid_terminator]))
     response = conn.response_class(conn.sock, method='GET')
     response.begin()
     actual_resp_body = response.read()

--- a/cheroot/test/test_conn.py
+++ b/cheroot/test/test_conn.py
@@ -838,8 +838,7 @@ def test_Chunked_Encoding(test_client):
 
     # Try a chunked request that exceeds server.max_request_body_size.
     # Note that the delimiters and trailer are included.
-    body = '{}{}{}'.format('3e3\r\n', 'x' * 995, '\r\n0\r\n\r\n') \
-        .encode('ascii')
+    body = b'\r\n'.join((b'3e3', b'x' * 995, b'0', b'', b''))
     conn.putrequest('POST', '/upload', skip_host=True)
     conn.putheader('Host', conn.host)
     conn.putheader('Transfer-Encoding', 'chunked')
@@ -972,8 +971,8 @@ def test_No_CRLF(test_client, invalid_terminator):
     # Initialize a persistent HTTP connection
     conn = test_client.get_connection()
 
-    conn.send('GET /hello HTTP/1.1{}'.format(invalid_terminator)
-                                     .encode('ascii'))
+    # (b'%s' % b'') is not supported in Python 3.4, so just use bytes.join()
+    conn.send(b''.join((b'GET /hello HTTP/1.1', invalid_terminator)))
     response = conn.response_class(conn.sock, method='GET')
     response.begin()
     actual_resp_body = response.read()

--- a/cheroot/test/test_conn.py
+++ b/cheroot/test/test_conn.py
@@ -839,7 +839,7 @@ def test_Chunked_Encoding(test_client):
     # Try a chunked request that exceeds server.max_request_body_size.
     # Note that the delimiters and trailer are included.
     body = '{}{}{}'.format('3e3\r\n', 'x' * 995, '\r\n0\r\n\r\n') \
-               .encode('ascii')
+        .encode('ascii')
     conn.putrequest('POST', '/upload', skip_host=True)
     conn.putheader('Host', conn.host)
     conn.putheader('Transfer-Encoding', 'chunked')

--- a/cheroot/test/test_ssl.py
+++ b/cheroot/test/test_ssl.py
@@ -189,7 +189,7 @@ def test_ssl_adapters(
     )
 
     resp = requests.get(
-        'https://%s:%s/' % (interface, port),
+        'https://{}:{}/'.format(interface, port),
         verify=tls_ca_certificate_pem_path,
     )
 
@@ -274,7 +274,7 @@ def test_tls_client_auth(
 
         make_https_request = functools.partial(
             requests.get,
-            'https://%s:%s/' % (interface, port),
+            'https://{}:{}/'.format(interface, port),
 
             # Server TLS certificate verification:
             verify=tls_ca_certificate_pem_path,
@@ -482,7 +482,7 @@ def test_http_over_https_error(
         expect_fallback_response_over_plain_http = False
     if expect_fallback_response_over_plain_http:
         resp = requests.get(
-            'http://%s:%s/' % (fqdn, port),
+            'http://{}:{}/'.format(fqdn, port),
         )
         assert resp.status_code == 400
         assert resp.text == (
@@ -493,7 +493,7 @@ def test_http_over_https_error(
 
     with pytest.raises(requests.exceptions.ConnectionError) as ssl_err:
         requests.get(  # FIXME: make stdlib ssl behave like PyOpenSSL
-            'http://%s:%s/' % (fqdn, port),
+            'http://{}:{}/'.format(fqdn, port),
         )
 
     if IS_LINUX:

--- a/cheroot/test/test_ssl.py
+++ b/cheroot/test/test_ssl.py
@@ -189,7 +189,7 @@ def test_ssl_adapters(
     )
 
     resp = requests.get(
-        'https://' + interface + ':' + str(port) + '/',
+        'https://%s:%s/' % (interface, port),
         verify=tls_ca_certificate_pem_path,
     )
 
@@ -274,7 +274,7 @@ def test_tls_client_auth(
 
         make_https_request = functools.partial(
             requests.get,
-            'https://' + interface + ':' + str(port) + '/',
+            'https://%s:%s/' % (interface, port),
 
             # Server TLS certificate verification:
             verify=tls_ca_certificate_pem_path,
@@ -482,7 +482,7 @@ def test_http_over_https_error(
         expect_fallback_response_over_plain_http = False
     if expect_fallback_response_over_plain_http:
         resp = requests.get(
-            'http://' + fqdn + ':' + str(port) + '/',
+            'http://%s:%s/' % (fqdn, port),
         )
         assert resp.status_code == 400
         assert resp.text == (
@@ -493,7 +493,7 @@ def test_http_over_https_error(
 
     with pytest.raises(requests.exceptions.ConnectionError) as ssl_err:
         requests.get(  # FIXME: make stdlib ssl behave like PyOpenSSL
-            'http://' + fqdn + ':' + str(port) + '/',
+            'http://%s:%s/' % (fqdn, port),
         )
 
     if IS_LINUX:

--- a/cheroot/test/test_ssl.py
+++ b/cheroot/test/test_ssl.py
@@ -189,7 +189,7 @@ def test_ssl_adapters(
     )
 
     resp = requests.get(
-        'https://{}:{}/'.format(interface, port),
+        'https://{host!s}:{port!s}/'.format(host=interface, port=port),
         verify=tls_ca_certificate_pem_path,
     )
 
@@ -274,7 +274,7 @@ def test_tls_client_auth(
 
         make_https_request = functools.partial(
             requests.get,
-            'https://{}:{}/'.format(interface, port),
+            'https://{host!s}:{port!s}/'.format(host=interface, port=port),
 
             # Server TLS certificate verification:
             verify=tls_ca_certificate_pem_path,
@@ -482,7 +482,7 @@ def test_http_over_https_error(
         expect_fallback_response_over_plain_http = False
     if expect_fallback_response_over_plain_http:
         resp = requests.get(
-            'http://{}:{}/'.format(fqdn, port),
+            'http://{host!s}:{port!s}/'.format(host=fqdn, port=port),
         )
         assert resp.status_code == 400
         assert resp.text == (
@@ -493,7 +493,7 @@ def test_http_over_https_error(
 
     with pytest.raises(requests.exceptions.ConnectionError) as ssl_err:
         requests.get(  # FIXME: make stdlib ssl behave like PyOpenSSL
-            'http://{}:{}/'.format(fqdn, port),
+            'http://{host!s}:{port!s}/'.format(host=fqdn, port=port),
         )
 
     if IS_LINUX:

--- a/cheroot/workers/threadpool.py
+++ b/cheroot/workers/threadpool.py
@@ -176,7 +176,7 @@ class ThreadPool:
         for i in range(self.min):
             self._threads.append(WorkerThread(self.server))
         for worker in self._threads:
-            worker.setName('CP Server ' + worker.getName())
+            worker.setName('CP Server %s' % (worker.getName()))
             worker.start()
         for worker in self._threads:
             while not worker.ready:
@@ -223,7 +223,7 @@ class ThreadPool:
 
     def _spawn_worker(self):
         worker = WorkerThread(self.server)
-        worker.setName('CP Server ' + worker.getName())
+        worker.setName('CP Server %s' % (worker.getName()))
         worker.start()
         return worker
 

--- a/cheroot/workers/threadpool.py
+++ b/cheroot/workers/threadpool.py
@@ -176,7 +176,7 @@ class ThreadPool:
         for i in range(self.min):
             self._threads.append(WorkerThread(self.server))
         for worker in self._threads:
-            worker.setName('CP Server %s' % (worker.getName()))
+            worker.setName('CP Server {}'.format(worker.getName()))
             worker.start()
         for worker in self._threads:
             while not worker.ready:
@@ -223,7 +223,7 @@ class ThreadPool:
 
     def _spawn_worker(self):
         worker = WorkerThread(self.server)
-        worker.setName('CP Server %s' % (worker.getName()))
+        worker.setName('CP Server {}'.format(worker.getName()))
         worker.start()
         return worker
 

--- a/cheroot/workers/threadpool.py
+++ b/cheroot/workers/threadpool.py
@@ -176,7 +176,10 @@ class ThreadPool:
         for i in range(self.min):
             self._threads.append(WorkerThread(self.server))
         for worker in self._threads:
-            worker.setName('CP Server {}'.format(worker.getName()))
+            worker.setName(
+                'CP Server {worker_name!s}'.
+                format(worker_name=worker.getName()),
+            )
             worker.start()
         for worker in self._threads:
             while not worker.ready:
@@ -223,7 +226,10 @@ class ThreadPool:
 
     def _spawn_worker(self):
         worker = WorkerThread(self.server)
-        worker.setName('CP Server {}'.format(worker.getName()))
+        worker.setName(
+            'CP Server {worker_name!s}'.
+            format(worker_name=worker.getName()),
+        )
         worker.start()
         return worker
 

--- a/cheroot/wsgi.py
+++ b/cheroot/wsgi.py
@@ -300,7 +300,7 @@ class Gateway_10(Gateway):
 
         # Request headers
         env.update(
-            ('HTTP_%s' % (bton(k).upper().replace('-', '_')), bton(v))
+            ('HTTP_{!s}'.format(bton(k).upper().replace('-', '_')), bton(v))
             for k, v in req.inheaders.items()
         )
 
@@ -409,7 +409,7 @@ class PathInfoDispatcher:
         path = environ['PATH_INFO'] or '/'
         for p, app in self.apps:
             # The apps list should be sorted by length, descending.
-            if path.startswith('%s/' % (p)) or path == p:
+            if path.startswith('{path!s}/'.format(path=p)) or path == p:
                 environ = environ.copy()
                 environ['SCRIPT_NAME'] = environ.get('SCRIPT_NAME', '') + p
                 environ['PATH_INFO'] = path[len(p):]

--- a/cheroot/wsgi.py
+++ b/cheroot/wsgi.py
@@ -300,7 +300,7 @@ class Gateway_10(Gateway):
 
         # Request headers
         env.update(
-            ('HTTP_' + bton(k).upper().replace('-', '_'), bton(v))
+            ('HTTP_%s' % (bton(k).upper().replace('-', '_')), bton(v))
             for k, v in req.inheaders.items()
         )
 
@@ -409,7 +409,7 @@ class PathInfoDispatcher:
         path = environ['PATH_INFO'] or '/'
         for p, app in self.apps:
             # The apps list should be sorted by length, descending.
-            if path.startswith(p + '/') or path == p:
+            if path.startswith('%s/' % (p)) or path == p:
                 environ = environ.copy()
                 environ['SCRIPT_NAME'] = environ.get('SCRIPT_NAME', '') + p
                 environ['PATH_INFO'] = path[len(p):]


### PR DESCRIPTION
❓ **What kind of change does this PR introduce?**
  - [ ] 🐞 bug fix
  - [ ] 🐣 feature
  - [ ] 📋 docs update
  - [ ] 📋 tests/coverage improvement
  - [x] 📋 refactoring
  - [ ] 💥 other

📋 **What is the related issue number (starting with `#`)**

#253 - flake8 style cleanup.

❓ **What is the current behavior?** (You can also link to an open issue here)

```
➜  cheroot git:(master) ✗ flake8 . | grep WPS336
./cheroot/server.py:159:33: WPS336 Found explicit string concat
./cheroot/server.py:470:30: WPS336 Found explicit string concat
./cheroot/server.py:825:47: WPS336 Found explicit string concat
./cheroot/server.py:1041:20: WPS336 Found explicit string concat
./cheroot/server.py:1502:15: WPS336 Found explicit string concat
./cheroot/server.py:1808:32: WPS336 Found explicit string concat
./cheroot/wsgi.py:303:14: WPS336 Found explicit string concat
./cheroot/wsgi.py:412:36: WPS336 Found explicit string concat
./cheroot/test/test_conn.py:841:12: WPS336 Found explicit string concat
./cheroot/test/test_conn.py:841:40: WPS336 Found explicit string concat
./cheroot/test/test_conn.py:975:15: WPS336 Found explicit string concat
./cheroot/test/test_ssl.py:192:9: WPS336 Found explicit string concat
./cheroot/test/test_ssl.py:192:34: WPS336 Found explicit string concat
./cheroot/test/test_ssl.py:192:52: WPS336 Found explicit string concat
./cheroot/test/test_ssl.py:277:13: WPS336 Found explicit string concat
./cheroot/test/test_ssl.py:277:38: WPS336 Found explicit string concat
./cheroot/test/test_ssl.py:277:56: WPS336 Found explicit string concat
./cheroot/test/test_ssl.py:485:13: WPS336 Found explicit string concat
./cheroot/test/test_ssl.py:485:32: WPS336 Found explicit string concat
./cheroot/test/test_ssl.py:485:50: WPS336 Found explicit string concat
./cheroot/test/test_ssl.py:496:13: WPS336 Found explicit string concat
./cheroot/test/test_ssl.py:496:32: WPS336 Found explicit string concat
./cheroot/test/test_ssl.py:496:50: WPS336 Found explicit string concat
./cheroot/workers/threadpool.py:179:28: WPS336 Found explicit string concat
./cheroot/workers/threadpool.py:226:24: WPS336 Found explicit string concat
```

❓ **What is the new behavior (if this is a feature change)?**

```
➜  cheroot git:(master) flake8 . | grep WPS336
➜  cheroot git:(master) 
```

📋 **Other information**:



📋 **Checklist**:

  - [x] I think the code is well written
  - [x] I wrote [good commit messages][1]
  - [ ] I have [squashed related commits together][2] after the changes have been approved
  - [x] Unit tests for the changes exist
  - [x] Integration tests for the changes exist (if applicable)
  - [x] I used the same coding conventions as the rest of the project
  - [x] The new code doesn't generate linter offenses
  - [x] Documentation reflects the changes
  - [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences

[1]: http://chris.beams.io/posts/git-commit/
[2]: https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cherrypy/cheroot/254)
<!-- Reviewable:end -->
