### PR TITLE
Be more graceful when terminating keep-alive connections

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,8 @@
+.. scm-version-title:: v8.3.1
+
+- Made terminating keep-alive connections more graceful
+  (:issue:`263` via :pr:`277`).
+
 .. scm-version-title:: v8.3.0
 
 - :cp-issue:`910` via :pr:`243`: Provide TLS-related

--- a/cheroot/connections.py
+++ b/cheroot/connections.py
@@ -91,12 +91,6 @@ class ConnectionManager:
         if conn.closeable:
             return
 
-        # Too many connections?
-        ka_limit = self.server.keep_alive_conn_limit
-        if ka_limit is not None and len(self.connections) > ka_limit:
-            conn.closeable = True
-            return
-
         # Connection too old?
         if (conn.last_used + self.server.timeout) < time.time():
             conn.closeable = True
@@ -277,3 +271,9 @@ class ConnectionManager:
         for conn in self.connections[:]:
             conn.close()
         self.connections = []
+
+    @property
+    def can_add_keepalive_connection(self):
+        ka_limit = self.server.keep_alive_conn_limit
+        stats = [ka_limit, len(self.connections)]
+        return ka_limit is None or len(self.connections) < ka_limit

--- a/cheroot/connections.py
+++ b/cheroot/connections.py
@@ -274,5 +274,6 @@ class ConnectionManager:
 
     @property
     def can_add_keepalive_connection(self):
+        """Flag whether it is allowed to add a new keep-alive connection."""
         ka_limit = self.server.keep_alive_conn_limit
         return ka_limit is None or len(self.connections) < ka_limit

--- a/cheroot/connections.py
+++ b/cheroot/connections.py
@@ -275,5 +275,4 @@ class ConnectionManager:
     @property
     def can_add_keepalive_connection(self):
         ka_limit = self.server.keep_alive_conn_limit
-        stats = [ka_limit, len(self.connections)]
         return ka_limit is None or len(self.connections) < ka_limit

--- a/cheroot/server.py
+++ b/cheroot/server.py
@@ -1159,6 +1159,12 @@ class HTTPRequest:
                     # Closing the conn is the only way to determine len.
                     self.close_connection = True
 
+        # Override the decision to not close the connection if the connection
+        # manager doesn't have space for it.
+        if not self.close_connection:
+            can_keep = self.server.connections.can_add_keepalive_connection
+            self.close_connection = not can_keep
+
         if b'connection' not in hkeys:
             if self.response_protocol == 'HTTP/1.1':
                 # Both server and client are HTTP/1.1 or better

--- a/cheroot/server.py
+++ b/cheroot/server.py
@@ -2024,7 +2024,7 @@ class HTTPServer:
                 # Just drop the conn. TODO: write 503 back?
                 conn.close()
 
-        #self.connections.expire()
+        self.connections.expire()
 
     @property
     def interrupt(self):

--- a/cheroot/server.py
+++ b/cheroot/server.py
@@ -2024,7 +2024,7 @@ class HTTPServer:
                 # Just drop the conn. TODO: write 503 back?
                 conn.close()
 
-        self.connections.expire()
+        #self.connections.expire()
 
     @property
     def interrupt(self):

--- a/cheroot/test/test_conn.py
+++ b/cheroot/test/test_conn.py
@@ -409,7 +409,7 @@ def test_keepalive_conn_management(test_client):
         http_connection.connect()
         return http_connection
 
-    def request(conn):
+    def request(conn, keepalive=True):
         status_line, actual_headers, actual_resp_body = test_client.get(
             '/page3', headers=[('Connection', 'Keep-Alive')],
             http_conn=conn, protocol='HTTP/1.0',
@@ -418,7 +418,10 @@ def test_keepalive_conn_management(test_client):
         assert actual_status == 200
         assert status_line[4:] == 'OK'
         assert actual_resp_body == pov.encode()
-        assert header_has_value('Connection', 'Keep-Alive', actual_headers)
+        if keepalive:
+            assert header_has_value('Connection', 'Keep-Alive', actual_headers)
+        else:
+            assert not header_exists('Connection', actual_headers)
 
     disconnect_errors = (
         http_client.BadStatusLine,
@@ -437,28 +440,21 @@ def test_keepalive_conn_management(test_client):
     # Reusing the first connection should still work.
     request(c1)
 
-    # Creating a new connection should still work.
+    # Creating a new connection should still work, but we should
+    # have run out of available connections to keep alive, so the
+    # server should tell us to close.
     c3 = connection()
-    request(c3)
+    request(c3, keepalive=False)
 
-    # Allow a tick.
-    time.sleep(0.2)
-
-    # That's three connections, we should expect the one used less recently
-    # to be expired.
+    # Show that the third connection was closed.
     with pytest.raises(disconnect_errors):
-        request(c2)
-
-    # But the oldest created one should still be valid.
-    # (As well as the newest one).
-    request(c1)
-    request(c3)
+        request(c3)
 
     # Wait for some of our timeout.
-    time.sleep(1.0)
+    time.sleep(1.2)
 
-    # Refresh the third connection.
-    request(c3)
+    # Refresh the second connection.
+    request(c2)
 
     # Wait for the remainder of our timeout, plus one tick.
     time.sleep(1.2)
@@ -467,9 +463,10 @@ def test_keepalive_conn_management(test_client):
     with pytest.raises(disconnect_errors):
         request(c1)
 
-    # But the third one should still be valid.
-    request(c3)
+    # But the second one should still be valid.
+    request(c2)
 
+    # Restore original timeout.
     test_client.server_instance.timeout = timeout
 
 

--- a/cheroot/test/test_wsgi.py
+++ b/cheroot/test/test_wsgi.py
@@ -30,7 +30,6 @@ def simple_wsgi_server():
         yield locals()
 
 
-@pytest.mark.xfail(reason='#263')
 def test_connection_keepalive(simple_wsgi_server):
     """Test the connection keepalive works (duh)."""
     session = Session(base_url=simple_wsgi_server['url'])

--- a/cheroot/test/test_wsgi.py
+++ b/cheroot/test/test_wsgi.py
@@ -9,6 +9,10 @@ from requests_toolbelt.sessions import BaseUrlSession as Session
 from jaraco.context import ExceptionTrap
 
 from cheroot import wsgi
+from cheroot._compat import IS_MACOS, IS_WINDOWS
+
+
+IS_SLOW_ENV = IS_MACOS or IS_WINDOWS
 
 
 @pytest.fixture
@@ -24,7 +28,7 @@ def simple_wsgi_server():
 
     host = '::'
     addr = host, port
-    server = wsgi.Server(addr, app, timeout=20)
+    server = wsgi.Server(addr, app, timeout=600 if IS_SLOW_ENV else 20)
     url = 'http://localhost:{port}/'.format(**locals())
     with server._run_in_thread() as thread:
         yield locals()
@@ -44,10 +48,10 @@ def test_connection_keepalive(simple_wsgi_server):
             resp.raise_for_status()
         return bool(trap)
 
-    with ThreadPoolExecutor(max_workers=50) as pool:
+    with ThreadPoolExecutor(max_workers=10 if IS_SLOW_ENV else 50) as pool:
         tasks = [
             pool.submit(do_request)
-            for n in range(1000)
+            for n in range(250 if IS_SLOW_ENV else 1000)
         ]
         failures = sum(task.result() for task in tasks)
 

--- a/cheroot/test/test_wsgi.py
+++ b/cheroot/test/test_wsgi.py
@@ -24,7 +24,7 @@ def simple_wsgi_server():
 
     host = '::'
     addr = host, port
-    server = wsgi.Server(addr, app)
+    server = wsgi.Server(addr, app, timeout=20)
     url = 'http://localhost:{port}/'.format(**locals())
     with server._run_in_thread() as thread:
         yield locals()


### PR DESCRIPTION
❓ **What kind of change does this PR introduce?**
  - [X] 🐞 bug fix
  - [ ] 🐣 feature
  - [ ] 📋 docs update
  - [ ] 📋 tests/coverage improvement
  - [ ] 📋 refactoring
  - [ ] 💥 other

📋 **What is the related issue number (starting with `#`)**

Fixes #263 

❓ **What is the current behavior?** (You can also link to an open issue here)

Current mechanism for managing keep-alive connections will forcibly close the least recently-used connection to ensure that we keep to the threshold of the maximum number of allowed keep-alive connections.

❓ **What is the new behavior (if this is a feature change)?**

Examine if we have reached the threshold of keep-alive connections before writing response headers - if we have, then write the appropriate response headers to close the connection, rather than keeping the connection alive (even if the client has requested it).

📋 **Other information**:



📋 **Checklist**:

  - [X] I think the code is well written
  - [X] I wrote [good commit messages][1]
  - [ ] I have [squashed related commits together][2] after the changes have been approved
  - [X] Unit tests for the changes exist
  - [-] Integration tests for the changes exist (if applicable)
  - [X] I used the same coding conventions as the rest of the project
  - [ ] The new code doesn't generate linter offenses
  - [-] Documentation reflects the changes
  - [X] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences

[1]: http://chris.beams.io/posts/git-commit/
[2]: https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cherrypy/cheroot/277)
<!-- Reviewable:end -->
