### PR TITLE
Avoid possible race condition on persistent HTTP connections

### DIFF
--- a/cheroot/server.py
+++ b/cheroot/server.py
@@ -1175,6 +1175,11 @@ class HTTPRequest:
                 if not self.close_connection:
                     self.outheaders.append((b'Connection', b'Keep-Alive'))
 
+        self.outheaders.append((
+            b'Keep-Alive',
+            "timeout={}".format(self.server.timeout).encode('ISO-8859-1'),
+        ))
+
         if (not self.close_connection) and (not self.chunked_read):
             # Read any remaining request body data on the socket.
             # "If an origin server receives a request that does not include an

--- a/cheroot/server.py
+++ b/cheroot/server.py
@@ -1175,7 +1175,7 @@ class HTTPRequest:
                 if not self.close_connection:
                     self.outheaders.append((b'Connection', b'Keep-Alive'))
 
-        if dict(self.outheaders).get(b'Connection', b'') == b'Keep-Alive':
+        if (b'Connection', b'Keep-Alive') in self.outheaders:
             self.outheaders.append((
                 b'Keep-Alive',
                 u'timeout={}'.format(self.server.timeout).encode('ISO-8859-1'),

--- a/cheroot/server.py
+++ b/cheroot/server.py
@@ -1177,7 +1177,7 @@ class HTTPRequest:
 
         self.outheaders.append((
             b'Keep-Alive',
-            "timeout={}".format(self.server.timeout).encode('ISO-8859-1'),
+            'timeout={}'.format(self.server.timeout).encode('ISO-8859-1'),
         ))
 
         if (not self.close_connection) and (not self.chunked_read):

--- a/cheroot/server.py
+++ b/cheroot/server.py
@@ -1178,7 +1178,7 @@ class HTTPRequest:
         if dict(self.outheaders).get(b'Connection', b'') == b'Keep-Alive':
             self.outheaders.append((
                 b'Keep-Alive',
-                'timeout={}'.format(self.server.timeout).encode('ISO-8859-1'),
+                u'timeout={}'.format(self.server.timeout).encode('ISO-8859-1'),
             ))
 
         if (not self.close_connection) and (not self.chunked_read):

--- a/cheroot/server.py
+++ b/cheroot/server.py
@@ -1175,10 +1175,11 @@ class HTTPRequest:
                 if not self.close_connection:
                     self.outheaders.append((b'Connection', b'Keep-Alive'))
 
-        self.outheaders.append((
-            b'Keep-Alive',
-            'timeout={}'.format(self.server.timeout).encode('ISO-8859-1'),
-        ))
+        if dict(self.outheaders).get(b'Connection', b'') == b'Keep-Alive':
+            self.outheaders.append((
+                b'Keep-Alive',
+                'timeout={}'.format(self.server.timeout).encode('ISO-8859-1'),
+            ))
 
         if (not self.close_connection) and (not self.chunked_read):
             # Read any remaining request body data on the socket.

--- a/cheroot/test/test_conn.py
+++ b/cheroot/test/test_conn.py
@@ -401,11 +401,7 @@ def test_keepalive(test_client, http_server_protocol):
     assert status_line[4:] == 'OK'
     assert actual_resp_body == pov.encode()
     assert not header_exists('Connection', actual_headers)
-    assert header_has_value(
-        'Keep-Alive',
-        'timeout={}'.format(test_client.server_instance.timeout),
-        actual_headers,
-    )
+    assert not header_exists('Keep-Alive', actual_headers)
 
     test_client.server_instance.protocol = original_server_protocol
 
@@ -432,13 +428,14 @@ def test_keepalive_conn_management(test_client):
         assert actual_resp_body == pov.encode()
         if keepalive:
             assert header_has_value('Connection', 'Keep-Alive', actual_headers)
+            assert header_has_value(
+                'Keep-Alive',
+                'timeout={}'.format(test_client.server_instance.timeout),
+                actual_headers,
+            )
         else:
             assert not header_exists('Connection', actual_headers)
-        assert header_has_value(
-            'Keep-Alive',
-            'timeout={}'.format(test_client.server_instance.timeout),
-            actual_headers,
-        )
+            assert not header_exists('Keep-Alive', actual_headers)
 
     disconnect_errors = (
         http_client.BadStatusLine,

--- a/cheroot/test/test_conn.py
+++ b/cheroot/test/test_conn.py
@@ -385,9 +385,11 @@ def test_keepalive(test_client, http_server_protocol):
     assert status_line[4:] == 'OK'
     assert actual_resp_body == pov.encode()
     assert header_has_value('Connection', 'Keep-Alive', actual_headers)
-    assert header_has_value('Keep-Alive',
-                            'timeout={}'.format(test_client.server_instance.timeout),
-                            actual_headers)
+    assert header_has_value(
+        'Keep-Alive',
+        'timeout={}'.format(test_client.server_instance.timeout),
+        actual_headers,
+    )
 
     # Remove the keep-alive header again.
     status_line, actual_headers, actual_resp_body = test_client.get(
@@ -399,9 +401,11 @@ def test_keepalive(test_client, http_server_protocol):
     assert status_line[4:] == 'OK'
     assert actual_resp_body == pov.encode()
     assert not header_exists('Connection', actual_headers)
-    assert header_has_value('Keep-Alive',
-                            'timeout={}'.format(test_client.server_instance.timeout),
-                            actual_headers)
+    assert header_has_value(
+        'Keep-Alive',
+        'timeout={}'.format(test_client.server_instance.timeout),
+        actual_headers,
+    )
 
     test_client.server_instance.protocol = original_server_protocol
 
@@ -430,9 +434,11 @@ def test_keepalive_conn_management(test_client):
             assert header_has_value('Connection', 'Keep-Alive', actual_headers)
         else:
             assert not header_exists('Connection', actual_headers)
-        assert header_has_value('Keep-Alive',
-                                'timeout={}'.format(test_client.server_instance.timeout),
-                                actual_headers)
+        assert header_has_value(
+            'Keep-Alive',
+            'timeout={}'.format(test_client.server_instance.timeout),
+            actual_headers,
+        )
 
     disconnect_errors = (
         http_client.BadStatusLine,

--- a/cheroot/test/test_conn.py
+++ b/cheroot/test/test_conn.py
@@ -385,6 +385,7 @@ def test_keepalive(test_client, http_server_protocol):
     assert status_line[4:] == 'OK'
     assert actual_resp_body == pov.encode()
     assert header_has_value('Connection', 'Keep-Alive', actual_headers)
+    assert header_has_value('Keep-Alive', 'timeout={}'.format(test_client.server_instance.timeout), actual_headers)
 
     # Remove the keep-alive header again.
     status_line, actual_headers, actual_resp_body = test_client.get(
@@ -396,6 +397,7 @@ def test_keepalive(test_client, http_server_protocol):
     assert status_line[4:] == 'OK'
     assert actual_resp_body == pov.encode()
     assert not header_exists('Connection', actual_headers)
+    assert header_has_value('Keep-Alive', 'timeout={}'.format(test_client.server_instance.timeout), actual_headers)
 
     test_client.server_instance.protocol = original_server_protocol
 
@@ -424,6 +426,7 @@ def test_keepalive_conn_management(test_client):
             assert header_has_value('Connection', 'Keep-Alive', actual_headers)
         else:
             assert not header_exists('Connection', actual_headers)
+        assert header_has_value('Keep-Alive', 'timeout={}'.format(test_client.server_instance.timeout), actual_headers)
 
     disconnect_errors = (
         http_client.BadStatusLine,

--- a/cheroot/test/test_conn.py
+++ b/cheroot/test/test_conn.py
@@ -385,7 +385,9 @@ def test_keepalive(test_client, http_server_protocol):
     assert status_line[4:] == 'OK'
     assert actual_resp_body == pov.encode()
     assert header_has_value('Connection', 'Keep-Alive', actual_headers)
-    assert header_has_value('Keep-Alive', 'timeout={}'.format(test_client.server_instance.timeout), actual_headers)
+    assert header_has_value('Keep-Alive',
+                            'timeout={}'.format(test_client.server_instance.timeout),
+                            actual_headers)
 
     # Remove the keep-alive header again.
     status_line, actual_headers, actual_resp_body = test_client.get(
@@ -397,7 +399,9 @@ def test_keepalive(test_client, http_server_protocol):
     assert status_line[4:] == 'OK'
     assert actual_resp_body == pov.encode()
     assert not header_exists('Connection', actual_headers)
-    assert header_has_value('Keep-Alive', 'timeout={}'.format(test_client.server_instance.timeout), actual_headers)
+    assert header_has_value('Keep-Alive',
+                            'timeout={}'.format(test_client.server_instance.timeout),
+                            actual_headers)
 
     test_client.server_instance.protocol = original_server_protocol
 
@@ -426,7 +430,9 @@ def test_keepalive_conn_management(test_client):
             assert header_has_value('Connection', 'Keep-Alive', actual_headers)
         else:
             assert not header_exists('Connection', actual_headers)
-        assert header_has_value('Keep-Alive', 'timeout={}'.format(test_client.server_instance.timeout), actual_headers)
+        assert header_has_value('Keep-Alive',
+                                'timeout={}'.format(test_client.server_instance.timeout),
+                                actual_headers)
 
     disconnect_errors = (
         http_client.BadStatusLine,


### PR DESCRIPTION
❓ **What kind of change does this PR introduce?**
  - [x] 🐞 bug fix
  - [ ] 🐣 feature
  - [ ] 📋 docs update
  - [ ] 📋 tests/coverage improvement
  - [ ] 📋 refactoring
  - [ ] 💥 other

❓ **What is the current behavior?**

There is a race condition on persistent HTTP connections when a HTTP client reuses a connection where the `socket.timeout` (defined by HTTP Server "timeout" attribute) exception was already triggered on `cheroot` side, the connection was set to be closed but the actual FIN packet is not yet produced by the `HTTPConnection` ([1] and [2]).

When that happens, the client gets a "connection reset by peer" after writing the request:



```console
$ tcpdump  # cherrypy running at 9080 with default "timeout" = 10
...
5485	2020-05-06 11:07:50,199544	127.0.0.1	127.0.0.1	HTTP	382	POST /run HTTP/1.1  (application/json)
5486	2020-05-06 11:07:50,242602	127.0.0.1	127.0.0.1	TCP	66	9080 → 44766 [ACK] Seq=27867 Ack=10594 Win=96512 Len=0 TSval=693100054 TSecr=693100010
5487	2020-05-06 11:07:50,244742	127.0.0.1	127.0.0.1	TCP	361	9080 → 44766 [PSH, ACK] Seq=27867 Ack=10594 Win=96512 Len=295 TSval=693100056 TSecr=693100010 [TCP segment of a reassembled PDU]
5488	2020-05-06 11:07:50,244750	127.0.0.1	127.0.0.1	TCP	66	44766 → 9080 [ACK] Seq=10594 Ack=28162 Win=465536 Len=0 TSval=693100056 TSecr=693100056
5489	2020-05-06 11:07:50,244813	127.0.0.1	127.0.0.1	HTTP	555	HTTP/1.1 200 OK  (application/json)
5490	2020-05-06 11:07:50,244819	127.0.0.1	127.0.0.1	TCP	66	44766 → 9080 [ACK] Seq=10594 Ack=28651 Win=465536 Len=0 TSval=693100056 TSecr=693100056
5502	2020-05-06 11:08:00,919903	127.0.0.1	127.0.0.1	HTTP	382	POST /run HTTP/1.1  (application/json)
5503	2020-05-06 11:08:00,919911	127.0.0.1	127.0.0.1	TCP	66	9080 → 44766 [ACK] Seq=28651 Ack=10910 Win=98432 Len=0 TSval=693110731 TSecr=693110731
5509	2020-05-06 11:08:03,955156	127.0.0.1	127.0.0.1	TCP	66	9080 → 44766 [RST, ACK] Seq=28651 Ack=10910 Win=98432 Len=0 TSval=693113766 TSecr=693110731
```

Notice the time between last HTTP request finished (response) and next POST > 10 sec, the `socket.timeout` exception is raised and then "connection reset by peer":

```console
5489	2020-05-06 11:07:50,244813	127.0.0.1	127.0.0.1	HTTP	555	HTTP/1.1 200 OK  (application/json)
5490	2020-05-06 11:07:50,244819	127.0.0.1	127.0.0.1	TCP	66	44766 → 9080 [ACK] Seq=10594 Ack=28651 Win=465536 Len=0 TSval=693100056 TSecr=693100056
5502	2020-05-06 11:08:00,919903	127.0.0.1	127.0.0.1	HTTP	382	POST /run HTTP/1.1  (application/json)
```

This commit makes a HTTP client to know about this "Keep-Alive" idle timeout by exposing it on the HTTP "Keep-Alive" response header, so the connection won't be reused by the HTTP client if it was "idle" for that "timeout" after the last request response.

[1]: https://github.com/meaksh/cheroot/blob/107650d59cedf8ca614cee713f56148f975c3140/cheroot/server.py#L1352
[2]: https://github.com/meaksh/cheroot/blob/107650d59cedf8ca614cee713f56148f975c3140/cheroot/server.py#L736

❓ **What is the new behavior (if this is a feature change)?**

A HTTP client is now aware of "Keep-Alive" timeout and won't reuse that connection if the "idle" timeout was already reached.

📋 **Other information**:

📋 **Checklist**:

  - [x] I think the code is well written
  - [x] I wrote [good commit messages][1]
  - [x] I have [squashed related commits together][2] after the changes have been approved
  - [ ] Unit tests for the changes exist
  - [x] Integration tests for the changes exist (if applicable)
  - [x] I used the same coding conventions as the rest of the project
  - [x] The new code doesn't generate linter offenses
  - [ ] Documentation reflects the changes
  - [ ] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences

[1]: http://chris.beams.io/posts/git-commit/
[2]: https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cherrypy/cheroot/282)
<!-- Reviewable:end -->
