### PR TITLE
Properly close SSL socket in `_loopback_for_cert`

### DIFF
--- a/cheroot/test/test_ssl.py
+++ b/cheroot/test/test_ssl.py
@@ -406,6 +406,7 @@ def test_tls_client_auth(
     ),
 )
 def test_ssl_env(
+        recwarn,
         mocker,
         tls_http_server, adapter_type,
         ca, tls_verify_mode, tls_certificate,
@@ -486,6 +487,23 @@ def test_ssl_env(
                 'SSL_CLIENT_I_DN', 'SSL_CLIENT_S_DN',
             }:
                 assert key in env
+
+    # builtin ssl environment generation may use a loopback socket
+    # ensure no ResourceWarning was raised during the test
+    # NOTE: python 2.7 does not emit ResourceWarning for ssl sockets
+    for warn in recwarn:
+        if not issubclass(warn.category, ResourceWarning):
+            continue
+
+        # the tests can sporadically generate resource warnings due to timing issues
+        # all of these sporadic warnings appear to be about socket.socket
+        # and have been observed to come from requests connection pool
+        msg = str(warn.message)
+        if 'socket.socket' in msg:
+            pytest.xfail(
+                'Sometimes this test fails due to a socket.socket ResourceWarning:\n' + msg,
+            )
+        assert False, msg
 
 
 @pytest.mark.parametrize(

--- a/cheroot/test/test_ssl.py
+++ b/cheroot/test/test_ssl.py
@@ -508,7 +508,7 @@ def test_ssl_env(
                     msg,
                 )),
             )
-        pytest.fail(reason=msg)
+        pytest.fail(reason=msg)  # noqa: PT016
 
 
 @pytest.mark.parametrize(

--- a/cheroot/test/test_ssl.py
+++ b/cheroot/test/test_ssl.py
@@ -495,15 +495,20 @@ def test_ssl_env(
         if not issubclass(warn.category, ResourceWarning):
             continue
 
-        # the tests can sporadically generate resource warnings due to timing issues
+        # the tests can sporadically generate resource warnings
+        # due to timing issues
         # all of these sporadic warnings appear to be about socket.socket
         # and have been observed to come from requests connection pool
         msg = str(warn.message)
         if 'socket.socket' in msg:
             pytest.xfail(
-                'Sometimes this test fails due to a socket.socket ResourceWarning:\n' + msg,
+                '\n'.join((
+                    'Sometimes this test fails due to '
+                    'a socket.socket ResourceWarning:',
+                    msg,
+                )),
             )
-        assert False, msg
+        pytest.fail(reason=msg)
 
 
 @pytest.mark.parametrize(

--- a/cheroot/test/test_ssl.py
+++ b/cheroot/test/test_ssl.py
@@ -508,7 +508,7 @@ def test_ssl_env(
                     msg,
                 )),
             )
-        pytest.fail(reason=msg)  # noqa: PT016
+        pytest.fail(msg)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
❓ **What kind of change does this PR introduce?**
  - [x] 🐞 bug fix
  - [ ] 🐣 feature
  - [ ] 📋 docs update
  - [ ] 📋 tests/coverage improvement
  - [ ] 📋 refactoring
  - [ ] 💥 other

📋 **What is the related issue number (starting with `#`)**

Fixes #290 

❓ **What is the current behavior?** (You can also link to an open issue here)

From #290 :
> With python3 -X dev -X tracemalloc=5 on cheroot code with SSL, python gives a ResourceWarning

❓ **What is the new behavior (if this is a feature change)?**

No more ResourceWarning

📋 **Other information**:

While the original code (submitted in #243) closed the underlying loopback socket, it did not properly close the ssl wrappers. This PR fixes that.

This PR also updates the `test_ssl_env` test to fail if a `ResourceWarning` was emitted.

📋 **Checklist**:

  - [x] I think the code is well written
  - [x] I wrote [good commit messages][1]
  - [ ] I have [squashed related commits together][2] after the changes have been approved
  - [x] Unit tests for the changes exist
  - [ ] Integration tests for the changes exist (if applicable)
  - [x] I used the same coding conventions as the rest of the project
  - [x] The new code doesn't generate linter offenses
  - [ ] Documentation reflects the changes
  - [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences

[1]: http://chris.beams.io/posts/git-commit/
[2]: https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cherrypy/cheroot/291)
<!-- Reviewable:end -->
