### PR TITLE
Resolve unclosed resourcewarning in pyopenssl

### DIFF
--- a/cheroot/ssl/pyopenssl.py
+++ b/cheroot/ssl/pyopenssl.py
@@ -321,8 +321,11 @@ class pyOpenSSLAdapter(Adapter):
 
         if self.certificate:
             # Server certificate attributes
-            cert = open(self.certificate, 'rb').read()
-            cert = crypto.load_certificate(crypto.FILETYPE_PEM, cert)
+            with open(self.certificate, 'rb') as cert_file:
+                cert = crypto.load_certificate(
+                    crypto.FILETYPE_PEM, cert_file.read(),
+                )
+
             ssl_environ.update({
                 'SSL_SERVER_M_VERSION': cert.get_version(),
                 'SSL_SERVER_M_SERIAL': cert.get_serial_number(),


### PR DESCRIPTION
❓ **What kind of change does this PR introduce?**
  - [x] 🐞 bug fix
  - [ ] 🐣 feature
  - [ ] 📋 docs update
  - [ ] 📋 tests/coverage improvement
  - [ ] 📋 refactoring
  - [ ] 💥 other


❓ **What is the current behavior?** (You can also link to an open issue here)

If python is started using `-dev X` it will show a `ResourceWarning` about the openend certificate-file.


❓ **What is the new behavior (if this is a feature change)?**

No more `ResourceWarning`.


📋 **Other information**:

Simple fix.


📋 **Checklist**:

  - [x] I think the code is well written
  - [x] I wrote [good commit messages][1]
  - [x] I have [squashed related commits together][2] after the changes have been approved
  - [ ] Unit tests for the changes exist
  - [ ] Integration tests for the changes exist (if applicable)
  - [x] I used the same coding conventions as the rest of the project
  - [x] The new code doesn't generate linter offenses
  - [ ] Documentation reflects the changes
  - [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences

[1]: http://chris.beams.io/posts/git-commit/
[2]: https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cherrypy/cheroot/298)
<!-- Reviewable:end -->
