### PR TITLE
Use selectors lib to address select() fd num limit

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -32,7 +32,7 @@ jobs:
     steps:
     - uses: actions/checkout@master
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2.1.1
+      uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
     - name: Pip cache

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -32,7 +32,7 @@ jobs:
     steps:
     - uses: actions/checkout@master
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v2.1.1
       with:
         python-version: ${{ matrix.python-version }}
     - name: Pip cache

--- a/cheroot/_compat.py
+++ b/cheroot/_compat.py
@@ -1,3 +1,4 @@
+# pylint: disable=unused-import
 """Compatibility code for using Cheroot with various versions of Python."""
 
 from __future__ import absolute_import, division, print_function
@@ -11,7 +12,10 @@ import six
 try:
     import selectors  # lgtm [py/unused-import]
 except ImportError:
-    import selectors2 as selectors  # noqa: F401  # lgtm [py/unused-import]
+    try:
+        import selectors2 as selectors  # noqa: F401  # lgtm [py/unused-import]
+    except ImportError:
+        import selectors34 as selectors  # noqa: F401 # lgtm [py/unused-import]
 
 try:
     import ssl

--- a/cheroot/_compat.py
+++ b/cheroot/_compat.py
@@ -8,6 +8,12 @@ import re
 
 import six
 
+# Not used in this file, imported elsewhere as 'from ._compat import selectors'
+try:
+    import selectors
+except ImportError:
+    import selectors2 as selectors  # noqa: F401
+
 try:
     import ssl
     IS_ABOVE_OPENSSL10 = ssl.OPENSSL_VERSION_INFO >= (1, 1)

--- a/cheroot/_compat.py
+++ b/cheroot/_compat.py
@@ -8,11 +8,10 @@ import re
 
 import six
 
-# Not used in this file, imported elsewhere as 'from ._compat import selectors'
 try:
-    import selectors
+    import selectors  # lgtm [py/unused-import]
 except ImportError:
-    import selectors2 as selectors  # noqa: F401
+    import selectors2 as selectors  # noqa: F401  # lgtm [py/unused-import]
 
 try:
     import ssl

--- a/cheroot/_compat.py
+++ b/cheroot/_compat.py
@@ -12,10 +12,7 @@ import six
 try:
     import selectors  # lgtm [py/unused-import]
 except ImportError:
-    try:
-        import selectors2 as selectors  # noqa: F401  # lgtm [py/unused-import]
-    except ImportError:
-        import selectors34 as selectors  # noqa: F401 # lgtm [py/unused-import]
+    import selectors2 as selectors  # noqa: F401  # lgtm [py/unused-import]
 
 try:
     import ssl

--- a/cheroot/connections.py
+++ b/cheroot/connections.py
@@ -5,14 +5,11 @@ __metaclass__ = type
 
 import io
 import os
-try:
-    import selectors
-except ImportError:
-    import selectors2 as selectors
 import socket
 import time
 
 from . import errors
+from ._compat import selectors
 from .makefile import MakeFile
 
 import six

--- a/cheroot/connections.py
+++ b/cheroot/connections.py
@@ -174,7 +174,7 @@ class ConnectionManager:
                 # Make a list of all the other sockets ready to read
                 rlist.append(key.fd)
 
-        if new_connection is False:
+        if not new_connection:
             if len(rlist) == 0:
                 # If we didn't get any readable sockets, wait for the next tick
                 return None

--- a/cheroot/connections.py
+++ b/cheroot/connections.py
@@ -178,9 +178,9 @@ class ConnectionManager:
             if len(rlist) == 0:
                 # If we didn't get any readable sockets, wait for the next tick
                 return None
-            else:
-                # No new connection, but reuse existing socket.
-                conn = socket_dict[rlist.pop()]
+
+            # No new connection, but reuse the existing socket.
+            conn = socket_dict[rlist.pop()]
 
         # All remaining connections in rlist should be marked as ready.
         for fno in rlist:

--- a/cheroot/test/test_server.py
+++ b/cheroot/test/test_server.py
@@ -5,6 +5,7 @@
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
+from contextlib import closing
 import os
 import socket
 import tempfile
@@ -284,11 +285,8 @@ def test_high_number_of_file_descriptors():
         # This will trigger a crash if select() is used in the implementation
         httpserver.tick()
 
-        sock = socket.socket()
-        try:
+        with closing(socket.socket()) as sock:
             assert sock.fileno() >= 1024
-        finally:
-            sock.close()
 
     finally:
         # Close our open resources

--- a/cheroot/test/test_server.py
+++ b/cheroot/test/test_server.py
@@ -246,7 +246,8 @@ def test_peercreds_unix_sock_with_lookup(peercreds_enabled_server):
         'is not available on Windows.'
     ),
 )
-def test_high_number_of_file_descriptors():
+@pytest.mark.forked
+def test_high_number_of_file_descriptors(http_server):
     """Test the server does not crash with a high file-descriptor value.
 
     This test should cause a server crash, as the server will try to

--- a/cheroot/test/test_server.py
+++ b/cheroot/test/test_server.py
@@ -253,8 +253,10 @@ def test_high_number_of_file_descriptors(http_server):
     This test should cause a server crash, as the server will try to
     select() a file-descriptor higher than 1024.
     """
-    # Imported here, as it is not available on Windows
-    import resource
+    resource = pytest.importorskip(
+        'resource',
+        reason='The "resource" module is Unix-specific',
+    )
 
     # Get current resource limits to restore them later
     (soft_limit, hard_limit) = resource.getrlimit(resource.RLIMIT_NOFILE)

--- a/cheroot/test/test_server.py
+++ b/cheroot/test/test_server.py
@@ -247,7 +247,7 @@ def test_peercreds_unix_sock_with_lookup(peercreds_enabled_server):
     ),
 )
 @pytest.mark.forked
-def test_high_number_of_file_descriptors(http_server):
+def test_high_number_of_file_descriptors():
     """Test the server does not crash with a high file-descriptor value.
 
     This test shouldn't cause a server crash when trying to access
@@ -269,7 +269,9 @@ def test_high_number_of_file_descriptors(http_server):
     (soft_limit, hard_limit) = resource.getrlimit(resource.RLIMIT_NOFILE)
 
     # Create our server
-    httpserver = http_server.send((ANY_INTERFACE_IPV4, EPHEMERAL_PORT))
+    httpserver = HTTPServer(
+        bind_addr=(ANY_INTERFACE_IPV4, EPHEMERAL_PORT), gateway=Gateway,
+    )
     httpserver.prepare()
     # Hoard a lot of file descriptors by opening and storing a lot of sockets
     test_sockets = []

--- a/cheroot/test/test_server.py
+++ b/cheroot/test/test_server.py
@@ -262,7 +262,7 @@ def test_high_number_of_file_descriptors():
         # an error due to the file descriptor number being too high
         resource.setrlimit(
             resource.RLIMIT_NOFILE,
-            (increased_nofile_limit, increased_nofile_limit),
+            (increased_nofile_limit, hard_limit),
         )
 
         # Open a lot of file descriptors, so the next ones the server
@@ -284,4 +284,4 @@ def test_high_number_of_file_descriptors():
 
         # Reset the limit back to the soft limit
         # (setting the hard_limit is an error)
-        resource.setrlimit(resource.RLIMIT_NOFILE, (soft_limit, soft_limit))
+        resource.setrlimit(resource.RLIMIT_NOFILE, (soft_limit, hard_limit))

--- a/cheroot/test/test_server.py
+++ b/cheroot/test/test_server.py
@@ -269,10 +269,13 @@ def test_high_number_of_file_descriptors():
         # opens are higher than 1024
         for i in range(1024):
             test_sockets.append(socket.socket())
+        assert test_sockets[-1].fileno() >= 1024
 
         httpserver.prepare()
         # This will trigger a crash if select() is used in the implementation
         httpserver.tick()
+        with socket.socket() as sock:
+            assert sock.fileno() >= 1024
 
     finally:
         # Close our open resources

--- a/cheroot/test/test_server.py
+++ b/cheroot/test/test_server.py
@@ -244,7 +244,6 @@ def test_peercreds_unix_sock_with_lookup(peercreds_enabled_server):
     reason='This regression test is for a Linux bug, '
     'and the resource module is not available on Windows',
 )
-@pytest.mark.forked
 @pytest.mark.parametrize(
     'resource_limit',
     (
@@ -285,6 +284,12 @@ def test_high_number_of_file_descriptors(resource_limit):
     finally:
         # Stop our server
         httpserver.stop()
+
+
+if not IS_WINDOWS:
+    test_high_number_of_file_descriptors = pytest.mark.forked(
+        test_high_number_of_file_descriptors,
+    )
 
 
 @pytest.fixture

--- a/cheroot/test/test_server.py
+++ b/cheroot/test/test_server.py
@@ -261,9 +261,7 @@ def test_high_number_of_file_descriptors(http_server):
     increased_nofile_limit = 2048
 
     # Create our server
-    httpserver = HTTPServer(
-        bind_addr=(ANY_INTERFACE_IPV4, EPHEMERAL_PORT), gateway=Gateway,
-    )
+    httpserver = http_server.send((ANY_INTERFACE_IPV4, EPHEMERAL_PORT))
     # Hoard a lot of file descriptors by opening and storing a lot of sockets
     test_sockets = []
 

--- a/cheroot/test/test_server.py
+++ b/cheroot/test/test_server.py
@@ -250,8 +250,11 @@ def test_peercreds_unix_sock_with_lookup(peercreds_enabled_server):
 def test_high_number_of_file_descriptors(http_server):
     """Test the server does not crash with a high file-descriptor value.
 
-    This test should cause a server crash, as the server will try to
-    select() a file-descriptor higher than 1024.
+    This test shouldn't cause a server crash when trying to access
+    file-descriptor higher than 1024.
+
+    The earlier implementation used to rely on `select()` syscall that
+    doesn't support file descriptors with numbers higher than 1024.
     """
     resource = pytest.importorskip(
         'resource',

--- a/cheroot/test/test_server.py
+++ b/cheroot/test/test_server.py
@@ -241,13 +241,20 @@ def test_peercreds_unix_sock_with_lookup(peercreds_enabled_server):
 
 @pytest.mark.skipif(
     IS_WINDOWS,
-    reason=(
-        'This regression test is for a Linux bug, and the resource module '
-        'is not available on Windows'
-    ),
+    reason='This regression test is for a Linux bug, '
+    'and the resource module is not available on Windows',
 )
 @pytest.mark.forked
-def test_high_number_of_file_descriptors():
+@pytest.mark.parametrize(
+    'resource_limit',
+    (
+        1024,
+        2048,
+    ),
+    indirect=('resource_limit', ),
+)
+@pytest.mark.usefixtures('many_open_sockets')
+def test_high_number_of_file_descriptors(resource_limit):
     """Test the server does not crash with a high file-descriptor value.
 
     This test shouldn't cause a server crash when trying to access
@@ -256,61 +263,75 @@ def test_high_number_of_file_descriptors():
     The earlier implementation used to rely on `select()` syscall that
     doesn't support file descriptors with numbers higher than 1024.
     """
-    resource = pytest.importorskip(
-        'resource',
-        reason='The "resource" module is Unix-specific',
-    )
-
-    # We want to force the server to use a file-descriptor with a number above
-    # this value
-    high_fd_no = 1024
-
-    # Get current resource limits to restore them later
-    (soft_limit, hard_limit) = resource.getrlimit(resource.RLIMIT_NOFILE)
+    # We want to force the server to use a file-descriptor with
+    # a number above resource_limit
 
     # Create our server
     httpserver = HTTPServer(
         bind_addr=(ANY_INTERFACE_IPV4, EPHEMERAL_PORT), gateway=Gateway,
     )
     httpserver.prepare()
-    # Hoard a lot of file descriptors by opening and storing a lot of sockets
-    test_sockets = []
 
     try:
-        # We have to increase the nofile limit above 1024
-        # Otherwise we see a 'Too many files open' error, instead of
-        # an error due to the file descriptor number being too high
-        resource.setrlimit(
-            resource.RLIMIT_NOFILE,
-            (high_fd_no * 2, hard_limit),
-        )
-
-        # Open a lot of file descriptors, so the next one the server opens is
-        # a hight number
-        for i in range(high_fd_no):
-            sock = socket.socket()
-            test_sockets.append(sock)
-            # If we reach a high enough number, we don't need to open more
-            if sock.fileno() >= high_fd_no:
-                break
-        # Check we opened enough descriptors to reach a high number
-        assert test_sockets[-1].fileno() >= high_fd_no
-
         # This will trigger a crash if select() is used in the implementation
         httpserver.tick()
-
+    except:  # noqa: E722
+        raise  # only needed for `else` to work
+    else:
         # We use closing here for py2-compat
         with closing(socket.socket()) as sock:
             # Check new sockets created are still above our target number
-            assert sock.fileno() >= high_fd_no
+            assert sock.fileno() >= resource_limit
+    finally:
+        # Stop our server
+        httpserver.stop()
 
+
+@pytest.fixture
+def resource_limit(request):
+    """Set the resource limit two times bigger then requested."""
+    resource = pytest.importorskip(
+        'resource',
+        reason='The "resource" module is Unix-specific',
+    )
+
+    # Get current resource limits to restore them later
+    soft_limit, hard_limit = resource.getrlimit(resource.RLIMIT_NOFILE)
+
+    # We have to increase the nofile limit above 1024
+    # Otherwise we see a 'Too many files open' error, instead of
+    # an error due to the file descriptor number being too high
+    resource.setrlimit(
+        resource.RLIMIT_NOFILE,
+        (request.param * 2, hard_limit),
+    )
+
+    try:  # noqa: WPS501
+        yield request.param
+    finally:
+        # Reset the resource limit back to the original soft limit
+        resource.setrlimit(resource.RLIMIT_NOFILE, (soft_limit, hard_limit))
+
+
+@pytest.fixture
+def many_open_sockets(resource_limit):
+    """Allocate a lot of file descriptors by opening dummy sockets."""
+    # Hoard a lot of file descriptors by opening and storing a lot of sockets
+    test_sockets = []
+    # Open a lot of file descriptors, so the next one the server
+    # opens is a high number
+    try:
+        for i in range(resource_limit):
+            sock = socket.socket()
+            test_sockets.append(sock)
+            # If we reach a high enough number, we don't need to open more
+            if sock.fileno() >= resource_limit:
+                break
+        # Check we opened enough descriptors to reach a high number
+        the_highest_fileno = test_sockets[-1].fileno()
+        assert the_highest_fileno >= resource_limit
+        yield the_highest_fileno
     finally:
         # Close our open resources
         for test_socket in test_sockets:
             test_socket.close()
-
-        # Stop our server
-        httpserver.stop()
-
-        # Reset the resource limit back to the original soft limit
-        resource.setrlimit(resource.RLIMIT_NOFILE, (soft_limit, hard_limit))

--- a/cheroot/test/test_server.py
+++ b/cheroot/test/test_server.py
@@ -260,7 +260,7 @@ def test_high_number_of_file_descriptors(resource_limit):
     This test shouldn't cause a server crash when trying to access
     file-descriptor higher than 1024.
 
-    The earlier implementation used to rely on `select()` syscall that
+    The earlier implementation used to rely on ``select()`` syscall that
     doesn't support file descriptors with numbers higher than 1024.
     """
     # We want to force the server to use a file-descriptor with

--- a/cheroot/test/test_server.py
+++ b/cheroot/test/test_server.py
@@ -243,7 +243,7 @@ def test_peercreds_unix_sock_with_lookup(peercreds_enabled_server):
     IS_WINDOWS,
     reason=(
         'This regression test is for a Linux bug, and the resource module '
-        'is not available on Windows.'
+        'is not available on Windows'
     ),
 )
 @pytest.mark.forked

--- a/cheroot/test/test_server.py
+++ b/cheroot/test/test_server.py
@@ -274,8 +274,12 @@ def test_high_number_of_file_descriptors():
         httpserver.prepare()
         # This will trigger a crash if select() is used in the implementation
         httpserver.tick()
-        with socket.socket() as sock:
+
+        sock = socket.socket()
+        try:
             assert sock.fileno() >= 1024
+        finally:
+            sock.close()
 
     finally:
         # Close our open resources

--- a/cheroot/test/test_server.py
+++ b/cheroot/test/test_server.py
@@ -285,7 +285,7 @@ def test_high_number_of_file_descriptors():
         # This will trigger a crash if select() is used in the implementation
         httpserver.tick()
 
-        with closing(socket.socket()) as sock:
+        with closing(socket.socket()) as sock:  # closing is here for py2-compat
             assert sock.fileno() >= 1024
 
     finally:

--- a/cheroot/test/test_server.py
+++ b/cheroot/test/test_server.py
@@ -251,7 +251,7 @@ def test_peercreds_unix_sock_with_lookup(peercreds_enabled_server):
         1024,
         2048,
     ),
-    indirect=('resource_limit', ),
+    indirect=('resource_limit',),
 )
 @pytest.mark.usefixtures('many_open_sockets')
 def test_high_number_of_file_descriptors(resource_limit):

--- a/cheroot/test/test_server.py
+++ b/cheroot/test/test_server.py
@@ -266,9 +266,7 @@ def test_high_number_of_file_descriptors(http_server):
     (soft_limit, hard_limit) = resource.getrlimit(resource.RLIMIT_NOFILE)
 
     # Create our server
-    httpserver = HTTPServer(
-        bind_addr=(ANY_INTERFACE_IPV4, EPHEMERAL_PORT), gateway=Gateway,
-    )
+    httpserver = http_server.send((ANY_INTERFACE_IPV4, EPHEMERAL_PORT))
     httpserver.prepare()
     # Hoard a lot of file descriptors by opening and storing a lot of sockets
     test_sockets = []

--- a/cheroot/test/test_server.py
+++ b/cheroot/test/test_server.py
@@ -239,6 +239,7 @@ def test_peercreds_unix_sock_with_lookup(peercreds_enabled_server):
         assert peercreds_text_resp.text == expected_textcreds
 
 
+@unix_only_sock_test
 def test_high_number_of_file_descriptors():
     """Test the server does not crash with a high file-descriptor value.
 

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -45,6 +45,7 @@ ssl
 stdout
 subclasses
 submodules
+syscall
 systemd
 threadpool
 Tidelift

--- a/setup.cfg
+++ b/setup.cfg
@@ -65,7 +65,8 @@ setup_requires =
 # These are required in actual runtime:
 install_requires =
     backports.functools_lru_cache; python_version < '3.3'
-    selectors2; python_version< '3.4'
+    selectors2; python_version < '3.4' and (sys_platform != "win32" or (sys_platform == "win32" and python_version >= '3.0'))
+    selectors34; python_version < '3.0' and sys_platform == "win32"
     six>=1.11.0
     more_itertools>=2.6
     jaraco.functools

--- a/setup.cfg
+++ b/setup.cfg
@@ -65,6 +65,7 @@ setup_requires =
 # These are required in actual runtime:
 install_requires =
     backports.functools_lru_cache; python_version < '3.3'
+    selectors2; python_version< '3.4'
     six>=1.11.0
     more_itertools>=2.6
     jaraco.functools

--- a/setup.cfg
+++ b/setup.cfg
@@ -86,6 +86,7 @@ docs =
 
 testing =
     pytest>=4.6.6
+    pytest-forked>=1.2.0
     pytest-mock>=1.11.0
     pytest-sugar>=0.9.3
     pytest-testmon<1.0.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -65,8 +65,7 @@ setup_requires =
 # These are required in actual runtime:
 install_requires =
     backports.functools_lru_cache; python_version < '3.3'
-    selectors2; python_version < '3.4' and (sys_platform != "win32" or (sys_platform == "win32" and python_version >= '3.0'))
-    selectors34; python_version < '3.0' and sys_platform == "win32"
+    selectors2; python_version< '3.4'
     six>=1.11.0
     more_itertools>=2.6
     jaraco.functools

--- a/setup.cfg
+++ b/setup.cfg
@@ -86,7 +86,8 @@ docs =
 
 testing =
     pytest>=4.6.6
-    pytest-forked>=1.2.0
+    pytest-forked>=1.1.3; sys_platform != "win32" and python_version >= '3.0' and python_version <= '3.4'
+    pytest-forked>=1.2.0; sys_platform != "win32" and (python_version < '3.0' or python_version > '3.4')
     pytest-mock>=1.11.0
     pytest-sugar>=0.9.3
     pytest-testmon<1.0.0


### PR DESCRIPTION
❓ **What kind of change does this PR introduce?**
  - [x] 🐞 bug fix
  - [ ] 🐣 feature
  - [ ] 📋 docs update
  - [x] 📋 tests/coverage improvement
  - [ ] 📋 refactoring
  - [ ] 💥 other

📋 **What is the related issue number (starting with `#`)**

Fixes #249

❓ **What is the current behavior?** (You can also link to an open issue here)

`HTTPServer` errors if it tries to open a filedescriptor larger than `1024`.

❓ **What is the new behavior (if this is a feature change)?**

A failing test `test_high_number_of_file_descriptors` has been added to capture this error.

The call to `select` has been replaced with the `selectors/selectors2` module.

📋 **Other information**:


📋 **Checklist**:

  - [x] I think the code is well written
  - [x] I wrote [good commit messages][1]
  - [ ] I have [squashed related commits together][2] after the changes have been approved
  - [x] Unit tests for the changes exist
  - [ ] Integration tests for the changes exist (if applicable)
  - [x] I used the same coding conventions as the rest of the project
  - [ ] The new code doesn't generate linter offenses
  - [ ] Documentation reflects the changes
  - [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences

[1]: http://chris.beams.io/posts/git-commit/
[2]: https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cherrypy/cheroot/301)
<!-- Reviewable:end -->
