### PR TITLE
Fix ConnectionAbortedError in builtin ssl WSGI environment setup

### DIFF
--- a/cheroot/ssl/builtin.py
+++ b/cheroot/ssl/builtin.py
@@ -56,7 +56,8 @@ def _loopback_for_cert_thread(context, server):
     """Wrap a socket in ssl and perform the server-side handshake."""
     # As we only care about parsing the certificate, the failure of
     # which will cause an exception in ``_loopback_for_cert``,
-    # we can safely ignore connection and ssl related exceptions.
+    # we can safely ignore connection and ssl related exceptions. Ref:
+    # https://github.com/cherrypy/cheroot/issues/302#issuecomment-662592030
     with suppress(ssl.SSLError, OSError):
         with context.wrap_socket(
                 server, do_handshake_on_connect=True, server_side=True,

--- a/cheroot/ssl/builtin.py
+++ b/cheroot/ssl/builtin.py
@@ -52,6 +52,36 @@ def _assert_ssl_exc_contains(exc, *msgs):
     return any(m.lower() in err_msg_lower for m in msgs)
 
 
+def _loopback_for_cert_thread(context, server):
+    """Wrap a socket in ssl and perform the server-side handshake."""
+    # As we only care about parsing the certificate, the failure of
+    # which will cause an exception in ``_loopback_for_cert``,
+    # we can safely ignore connection and ssl related exceptions.
+    with suppress(ssl.SSLError, OSError):
+        with context.wrap_socket(
+                server, do_handshake_on_connect=True, server_side=True,
+        ) as ssl_sock:
+            # in TLS 1.3 (Python 3.7+, OpenSSL 1.1.1+), the server
+            # sends the client session tickets that can be used to
+            # resume the TLS session on a new connection without
+            # performing the full handshake again. session tickets are
+            # sent as a post-handshake message at some _unspecified_
+            # time and thus a successful connection may be closed
+            # without the client having received the tickets.
+            # Unfortunately, on Windows (Python 3.8+), this is treated
+            # as an incomplete handshake on the server side and a
+            # ``ConnectionAbortedError`` is raised.
+            # TLS 1.3 support is still incomplete in Python 3.8;
+            # there is no way for the client to wait for tickets.
+            # While not necessary for retrieving the parsed certificate,
+            # we send a tiny bit of data over the connection in an
+            # attempt to give the server a chance to send the session
+            # tickets and close the connection cleanly.
+            # Note that, as this is essentially a race condition,
+            # the error may still occur ocasionally.
+            ssl_sock.send(b'0000')
+
+
 def _loopback_for_cert(certificate, private_key, certificate_chain):
     """Create a loopback connection to parse a cert with a private key."""
     context = ssl.create_default_context(cafile=certificate_chain)
@@ -69,10 +99,7 @@ def _loopback_for_cert(certificate, private_key, certificate_chain):
         # when `close` is called, the SSL shutdown notice will be sent
         # and then python will wait to receive the corollary shutdown.
         thread = threading.Thread(
-            target=lambda: context.wrap_socket(
-                server, do_handshake_on_connect=True,
-                server_side=True,
-            ).close(),
+            target=_loopback_for_cert_thread, args=(context, server),
         )
         try:
             thread.start()
@@ -80,6 +107,7 @@ def _loopback_for_cert(certificate, private_key, certificate_chain):
                     client, do_handshake_on_connect=True,
                     server_side=False,
             ) as ssl_sock:
+                ssl_sock.recv(4)
                 return ssl_sock.getpeercert()
         finally:
             thread.join()

--- a/cheroot/test/test_ssl.py
+++ b/cheroot/test/test_ssl.py
@@ -169,7 +169,7 @@ def tls_certificate_private_key_pem_path(tls_certificate):
 
 def _thread_except_hook(exceptions, args):
     """Append uncaught exception ``args`` in threads to ``exceptions``."""
-    if args.exc_type == SystemExit:
+    if issubclass(args.exc_type, SystemExit):
         return
     # cannot store the exception, it references the thread's stack
     exceptions.append((
@@ -569,12 +569,12 @@ def test_ssl_env(
 
     # to perform the ssl handshake over that loopback socket,
     # the builtin ssl environment generation uses a thread
-    if thread_exceptions:
-        for _, _, trace in thread_exceptions:
-            print(trace, file=sys.stderr)
-        pytest.fail(
-            thread_exceptions[0][0].__name__ + ': ' + thread_exceptions[0][1],
-        )
+    for _, _, trace in thread_exceptions:
+        print(trace, file=sys.stderr)
+    assert not thread_exceptions, ': '.join((
+        thread_exceptions[0][0].__name__,
+        thread_exceptions[0][1],
+    ))
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
❓ **What kind of change does this PR introduce?**
  - [x] 🐞 bug fix
  - [ ] 🐣 feature
  - [ ] 📋 docs update
  - [ ] 📋 tests/coverage improvement
  - [ ] 📋 refactoring
  - [ ] 💥 other

📋 **What is the related issue number (starting with `#`)**

Fixes #302 

❓ **What is the current behavior?** (You can also link to an open issue here)

On Windows 10 with Python 3.8, using the builtin ssl module results in an uncaught ``ConnectionAbortedError`` from a thread during WSGI environment setup.

❓ **What is the new behavior (if this is a feature change)?**

The thread used during the builtin ssl WSGI environment setup no longer raises connection or ssl related exceptions.

📋 **Other information**:

The ``ConnectionAbortedError`` was raised by the server-side of a loopback connection due to the connection closing before it could send the client TLS 1.3 session tickets.

📋 **Checklist**:

  - [x] I think the code is well written
  - [x] I wrote [good commit messages][1]
  - [ ] I have [squashed related commits together][2] after the changes have been approved
  - [x] Unit tests for the changes exist
  - [ ] Integration tests for the changes exist (if applicable)
  - [x] I used the same coding conventions as the rest of the project
  - [x] The new code doesn't generate linter offenses
  - [ ] Documentation reflects the changes
  - [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences

[1]: http://chris.beams.io/posts/git-commit/
[2]: https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cherrypy/cheroot/306)
<!-- Reviewable:end -->
