### PR TITLE
Fix a significant performance regression introduced in v8.1.0

### DIFF
--- a/cheroot/connections.py
+++ b/cheroot/connections.py
@@ -136,9 +136,12 @@ class ConnectionManager:
         try:
             for fno in socket_dict:
                 self._selector.register(fno, selectors.EVENT_READ)
+            # The timeout value impacts performance and should be carefully
+            # chosen. Ref:
+            # github.com/cherrypy/cheroot/issues/305#issuecomment-663985165
             rlist = [
                 key.fd for key, _event
-                in self._selector.select(timeout=0.1)
+                in self._selector.select(timeout=0.01)
             ]
         except OSError:
             # Mark any connection which no longer appears valid.


### PR DESCRIPTION
❓ **What kind of change does this PR introduce?**
  - [ ] 🐞 bug fix
  - [X] 🐣 feature
  - [ ] 📋 docs update
  - [ ] 📋 tests/coverage improvement
  - [ ] 📋 refactoring
  - [ ] 💥 other

📋 **What is the related issue number (starting with `#`)**

Hotfixes #305 

❓ **What is the current behavior?** (You can also link to an open issue here)

Starting with v8.1, Cheroot's performance dropped in certain scenarios. See #305 for details.

❓ **What is the new behavior (if this is a feature change)?**

The suggested change restores (and tops) the performance again (see benchmarks in #305)


📋 **Other information**:

N/A

📋 **Checklist**:

  - [x] I think the code is well written
  - [x] I wrote [good commit messages][1]
  - [ ] I have [squashed related commits together][2] after the changes have been approved
  - [ ] Unit tests for the changes exist
  - [ ] Integration tests for the changes exist (if applicable)
  - [x] I used the same coding conventions as the rest of the project
  - [ ] The new code doesn't generate linter offenses
  - [ ] Documentation reflects the changes
  - [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences

[1]: http://chris.beams.io/posts/git-commit/
[2]: https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cherrypy/cheroot/308)
<!-- Reviewable:end -->
