### PR TITLE
connections: refactor, clarify selectors use

### DIFF
--- a/cheroot/connections.py
+++ b/cheroot/connections.py
@@ -65,7 +65,10 @@ class ConnectionManager:
         self._readable_conns = collections.deque()
         self._selector = selectors.DefaultSelector()
 
-        self._selector.register(server.socket.fileno(), selectors.EVENT_READ, data=server)
+        self._selector.register(
+            server.socket.fileno(),
+            selectors.EVENT_READ, data=server,
+        )
 
     def put(self, conn):
         """Put idle connection into the ConnectionManager to be managed.
@@ -80,7 +83,9 @@ class ConnectionManager:
         if conn.rfile.has_data():
             self._readable_conns.append(conn)
         else:
-            self._selector.register(conn.socket.fileno(), selectors.EVENT_READ, data=conn)
+            self._selector.register(
+                conn.socket.fileno(), selectors.EVENT_READ, data=conn,
+            )
 
     def expire(self):
         """Expire least recently used connections.
@@ -147,6 +152,7 @@ class ConnectionManager:
                 except OSError:
                     # Socket is invalid, close the connection
                     self._selector.unregister(key.fd)
+                    conn = key.data
                     conn.close()
 
             # Wait for the next tick to occur.
@@ -265,7 +271,7 @@ class ConnectionManager:
         self._readable_conns.clear()
 
         for _, key in self._selector.get_map().items():
-            if key.data != self.server: # server closes its own socket
+            if key.data != self.server:  # server closes its own socket
                 key.data.socket.close()
 
         self._selector.close()

--- a/cheroot/server.py
+++ b/cheroot/server.py
@@ -1225,9 +1225,7 @@ class HTTPConnection:
     peercreds_resolve_enabled = False
 
     # Fields set by ConnectionManager.
-    closeable = False
     last_used = None
-    ready_with_data = False
 
     def __init__(self, server, sock, makefile=MakeFile):
         """Initialize HTTPConnection instance.
@@ -1581,7 +1579,7 @@ class HTTPServer:
         self.requests = threadpool.ThreadPool(
             self, min=minthreads or 1, max=maxthreads,
         )
-        self.connections = connections.ConnectionManager(self)
+        self.serving = False
 
         if not server_name:
             server_name = self.version
@@ -1775,6 +1773,8 @@ class HTTPServer:
         self.socket.settimeout(1)
         self.socket.listen(self.request_queue_size)
 
+        self.connections = connections.ConnectionManager(self)
+
         # Create worker threads
         self.requests.start()
 
@@ -1783,6 +1783,7 @@ class HTTPServer:
 
     def serve(self):
         """Serve requests, after invoking :func:`prepare()`."""
+        self.serving = True
         while self.ready:
             try:
                 self.tick()
@@ -1794,12 +1795,7 @@ class HTTPServer:
                     traceback=True,
                 )
 
-            if self.interrupt:
-                while self.interrupt is True:
-                    # Wait for self.stop() to complete. See _set_interrupt.
-                    time.sleep(0.1)
-                if self.interrupt:
-                    raise self.interrupt
+        self.serving = False
 
     def start(self):
         """Run the server forever.
@@ -2017,10 +2013,7 @@ class HTTPServer:
 
     def tick(self):
         """Accept a new connection and put it on the Queue."""
-        if not self.ready:
-            return
-
-        conn = self.connections.get_conn(self.socket)
+        conn = self.connections.get_conn()
         if conn:
             try:
                 self.requests.put(conn)
@@ -2041,6 +2034,8 @@ class HTTPServer:
         self._interrupt = True
         self.stop()
         self._interrupt = interrupt
+        if self._interrupt:
+            raise self.interrupt
 
     def stop(self):
         """Gracefully shutdown a server that is serving forever."""
@@ -2048,6 +2043,10 @@ class HTTPServer:
         if self._start_time is not None:
             self._run_time += (time.time() - self._start_time)
         self._start_time = None
+
+        # ensure serve is no longer accessing socket, connections
+        while self.serving:
+            time.sleep(0.1)
 
         sock = getattr(self, 'socket', None)
         if sock:

--- a/cheroot/workers/threadpool.py
+++ b/cheroot/workers/threadpool.py
@@ -111,11 +111,6 @@ class WorkerThread(threading.Thread):
                 if conn is _SHUTDOWNREQUEST:
                     return
 
-                # Just close the connection and move on.
-                if conn.closeable:
-                    conn.close()
-                    continue
-
                 self.conn = conn
                 is_stats_enabled = self.server.stats['Enabled']
                 if is_stats_enabled:


### PR DESCRIPTION
❓ **What kind of change does this PR introduce?**
  - [ ] 🐞 bug fix
  - [ ] 🐣 feature
  - [ ] 📋 docs update
  - [ ] 📋 tests/coverage improvement
  - [x] 📋 refactoring
  - [ ] 💥 other

📋 **What is the related issue number (starting with `#`)**

Resolves #304

❓ **What is the current behavior?** (You can also link to an open issue here)

The usage of the selector in the connections module is not as clear as it could be, and results in unnecessary register/unregister calls.

❓ **What is the new behavior (if this is a feature change)?**

Should be no behavioral change.

A few unnecessary register/unregister calls to the selector are removed, and the code is (hopefully) a bit clearer.

📋 **Other information**:

This passes tests locally for me on macOS, python 3.8 but i couldn't easily figure out how to run the linting steps.

📋 **Checklist**:

  - [x] I think the code is well written
  - [x] I wrote [good commit messages][1]
  - [ ] I have [squashed related commits together][2] after the changes have been approved
  - [x] Unit tests for the changes exist
  - [x] Integration tests for the changes exist (if applicable)
  - [x] I used the same coding conventions as the rest of the project
  - [x] The new code doesn't generate linter offenses
  - [x] Documentation reflects the changes
  - [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences

[1]: http://chris.beams.io/posts/git-commit/
[2]: https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cherrypy/cheroot/309)
<!-- Reviewable:end -->
