### PR TITLE
Uncaught socket exception during timeout handling

### DIFF
--- a/cheroot/ssl/pyopenssl.py
+++ b/cheroot/ssl/pyopenssl.py
@@ -105,8 +105,14 @@ class SSLFileobjectMixin:
             except SSL.WantWriteError:
                 time.sleep(self.ssl_retry)
             except SSL.SysCallError as e:
-                if is_reader and e.args == (-1, 'Unexpected EOF'):
-                    return b''
+                if e.args == (-1, 'Unexpected EOF'):
+                    if is_reader:
+                        return b''
+                    else:
+                        # See #210. Prevents DOS attack caused by
+                        # silent connections lasting beyond connection
+                        # timeout length.
+                        raise errors.FatalSSLAlert(*e.args)
 
                 errnum = e.args[0]
                 if is_reader and errnum in errors.socket_errors_to_ignore:

--- a/cheroot/ssl/pyopenssl.py
+++ b/cheroot/ssl/pyopenssl.py
@@ -108,11 +108,10 @@ class SSLFileobjectMixin:
                 if e.args == (-1, 'Unexpected EOF'):
                     if is_reader:
                         return b''
-                    else:
-                        # See #210. Prevents DOS attack caused by
-                        # silent connections lasting beyond connection
-                        # timeout length.
-                        raise errors.FatalSSLAlert(*e.args)
+                    # See #210. Prevents DOS attack caused by
+                    # silent connections lasting beyond connection
+                    # timeout length.
+                    raise errors.FatalSSLAlert(*e.args)
 
                 errnum = e.args[0]
                 if is_reader and errnum in errors.socket_errors_to_ignore:


### PR DESCRIPTION
❓ **What kind of change does this PR introduce?**
  - [x] 🐞 bug fix
  - [ ] 🐣 feature
  - [ ] 📋 docs update
  - [ ] 📋 tests/coverage improvement
  - [ ] 📋 refactoring
  - [ ] 💥 other

📋 **What is the related issue number (starting with `#`)**

Fixes #210 

❓ **What is the current behavior?** (You can also link to an open issue here)

When connections with no content that last for longer than the connection timeout are made to a cheroot server backed by pyOpenSSL, the connection timeout on the server side also causes an unhandled socket error that causes the thread to be dropped. Eventually, the server will extinguish its thread pool and become unresponsive.

See https://github.com/cherrypy/cheroot/issues/210#issuecomment-668867894 

❓ **What is the new behavior (if this is a feature change)?**

Threads are not dropped when connections with no content that last longer than the connection timeout are made to the server.


📋 **Other information**:



📋 **Checklist**:

  - [x] I think the code is well written
  - [x] I wrote [good commit messages][1]
  - [x] I have [squashed related commits together][2] after the changes have been approved
  - [ ] Unit tests for the changes exist
  - [ ] Integration tests for the changes exist (if applicable)
  - [x] I used the same coding conventions as the rest of the project
  - [x] The new code doesn't generate linter offenses
  - [ ] Documentation reflects the changes
  - [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences

[1]: http://chris.beams.io/posts/git-commit/
[2]: https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cherrypy/cheroot/310)
<!-- Reviewable:end -->
