### PR TITLE
server: process connections as they become active, rather than on tick

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,11 @@
+.. scm-version-title:: v8.5.0
+
+- :issue:`305` via :pr:`311`: In
+  :py:class:`~cheroot.connections.ConnectionManager`,
+  process connections as they become active rather than
+  waiting for a ``tick`` event, addressing performance
+  degradation introduced in v8.1.0.
+
 .. scm-version-title:: v8.4.8
 
 - :issue:`317` via :pr:`337`: Fixed a regression in

--- a/cheroot/server.py
+++ b/cheroot/server.py
@@ -7,12 +7,13 @@ sticking incoming connections onto a Queue::
 
     server = HTTPServer(...)
     server.start()
-    ->  while True:
-            tick()
-            # This blocks until a request comes in:
-            child = socket.accept()
-            conn = HTTPConnection(child, ...)
-            server.requests.put(conn)
+    ->  serve()
+        while ready:
+            _connections.run()
+                while not stop_requested:
+                    child = socket.accept()  # blocks until a request comes in
+                    conn = HTTPConnection(child, ...)
+                    server.process_conn(conn)  # adds conn to threadpool
 
 Worker threads are kept in a pool and poll the Queue, popping off and then
 handling each connection in turn. Each connection can consist of an arbitrary
@@ -1523,6 +1524,11 @@ class HTTPServer:
     timeout = 10
     """The timeout in seconds for accepted connections (default 10)."""
 
+    expiration_interval = 0.5
+    """The interval, in seconds, at which the server checks for
+    expired connections (default 0.5).
+    """
+
     version = 'Cheroot/{version!s}'.format(version=__version__)
     """A version string for the HTTPServer."""
 
@@ -1592,7 +1598,6 @@ class HTTPServer:
         self.requests = threadpool.ThreadPool(
             self, min=minthreads or 1, max=maxthreads,
         )
-        self.serving = False
 
         if not server_name:
             server_name = self.version
@@ -1797,20 +1802,16 @@ class HTTPServer:
 
     def serve(self):
         """Serve requests, after invoking :func:`prepare()`."""
-        self.serving = True
         while self.ready:
             try:
-                self.tick()
+                self._connections.run(self.expiration_interval)
             except (KeyboardInterrupt, SystemExit):
-                self.serving = False
                 raise
             except Exception:
                 self.error_log(
-                    'Error in HTTPServer.tick', level=logging.ERROR,
+                    'Error in HTTPServer.serve', level=logging.ERROR,
                     traceback=True,
                 )
-
-        self.serving = False
 
     def start(self):
         """Run the server forever.
@@ -2039,17 +2040,13 @@ class HTTPServer:
 
         return bind_addr
 
-    def tick(self):
-        """Accept a new connection and put it on the Queue."""
-        conn = self._connections.get_conn()
-        if conn:
-            try:
-                self.requests.put(conn)
-            except queue.Full:
-                # Just drop the conn. TODO: write 503 back?
-                conn.close()
-
-        self._connections.expire()
+    def process_conn(self, conn):
+        """Process an incoming HTTPConnection."""
+        try:
+            self.requests.put(conn)
+        except queue.Full:
+            # Just drop the conn. TODO: write 503 back?
+            conn.close()
 
     @property
     def interrupt(self):
@@ -2067,14 +2064,15 @@ class HTTPServer:
 
     def stop(self):  # noqa: C901  # FIXME
         """Gracefully shutdown a server that is serving forever."""
+        if not self.ready:
+            return  # already stopped
+
         self.ready = False
         if self._start_time is not None:
             self._run_time += (time.time() - self._start_time)
         self._start_time = None
 
-        # ensure serve is no longer accessing socket, connections
-        while self.serving:
-            time.sleep(0.1)
+        self._connections.stop()
 
         sock = getattr(self, 'socket', None)
         if sock:

--- a/cheroot/test/test_conn.py
+++ b/cheroot/test/test_conn.py
@@ -1145,6 +1145,6 @@ def test_invalid_selected_connection(test_client, monkeypatch):
     # trigger the internal errors
     faux_get_map.sabotage_conn = faux_select.request_served = True
     # give time to make sure the error gets handled
-    time.sleep(0.2)
+    time.sleep(test_client.server_instance.expiration_interval * 2)
     assert faux_select.os_error_triggered
     assert faux_get_map.conn_closed

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -108,6 +108,7 @@ nitpick_ignore = [
     ('py:class', '_pyio.BufferedWriter'),
     ('py:class', '_pyio.BufferedReader'),
     ('py:class', 'unittest.case.TestCase'),
+    ('py:meth', 'cheroot.connections.ConnectionManager.get_conn'),
 ]
 
 # Ref:


### PR DESCRIPTION
❓ **What kind of change does this PR introduce?**
  - [ ] 🐞 bug fix
  - [ ] 🐣 feature
  - [ ] 📋 docs update
  - [ ] 📋 tests/coverage improvement
  - [x] 📋 refactoring
  - [ ] 💥 other

📋 **What is the related issue number (starting with `#`)**

Fixes #305

❓ **What is the current behavior?** (You can also link to an open issue here)

Currently, the server `tick()`s in order to retrieve connections to process. However, in the current implementation, even if connections are previously marked as ready for processing, they are not returned from `connections.get_conn()` until after polling the selector. This means the processing of each connection may incur the latency of the polling timeout interval.

This addresses #305 in a more robust way, since this means the timeout specified to `select()` does not meaningfully impact the latency with which connections are processed.

❓ **What is the new behavior (if this is a feature change)?**

Instead of caching read-ready connections in `connections`, instead push new connections directly into the thread pool (via the server) as they become available. Any back pressure from the thread pool queue will propagate to `connections`, meaning subsequent polling of the selector will be delayed in the event that no workers are available, which is appropriate.

📋 **Other information**:

Tests and lint pass locally for me on macOS, python 3.8

It is probably worth repeating some of the performance testing done in https://github.com/cherrypy/cheroot/issues/305 to verify this - I have not yet reproduced per the notes in that issue, if anybody can assist that would be 👍

Performance gains may not be substantial, but I think the structure is easier to understand in any event.

Please let me know how best to handle what may be a breaking api change from `tick()` -> `serve()` or please update the PR directly if you prefer.

📋 **Checklist**:

  - [x] I think the code is well written
  - [x] I wrote [good commit messages][1]
  - [x] I have [squashed related commits together][2] after the changes have been approved
  - [x] Unit tests for the changes exist
  - [x] Integration tests for the changes exist (if applicable)
  - [x] I used the same coding conventions as the rest of the project
  - [x] The new code doesn't generate linter offenses
  - [x] Documentation reflects the changes
  - [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences

[1]: http://chris.beams.io/posts/git-commit/
[2]: https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cherrypy/cheroot/311)
<!-- Reviewable:end -->
