### PR TITLE
Implement contention via lock for the selectors in ConnectionManager.

### DIFF
--- a/cheroot/connections.py
+++ b/cheroot/connections.py
@@ -8,6 +8,7 @@ import io
 import os
 import socket
 import time
+import threading
 
 from . import errors
 from ._compat import selectors
@@ -49,6 +50,83 @@ else:
         fcntl.fcntl(fd, fcntl.F_SETFD, old_flags | fcntl.FD_CLOEXEC)
 
 
+class _SelectorManager:
+    """Private wrapper of a selectors.DefaultSelector instance.
+
+    Manage an external set of the keys that can be copied to be
+    safely iterated, in addition it implements some convenient
+    wrappers given the use that we have in the
+    ``ConnectionManager`` class  of the ``DefaultSelector`` instance.
+
+    The locking mechanism in this class is not strictly required
+    (if we make sure we don't register/unregister any fd concurrently
+    from a copy of the internal keys), but currently is the most
+    stable approach.
+    """
+
+    def __init__(self):
+        self._selector = selectors.DefaultSelector()
+        self._selector_keys = set([])
+        # The use of the lock shouldn't be necessary...
+        # but in practice it is.
+        #
+        # TODO: make sure we have a good understanding on how the
+        # Selectors instances are meant to be managed in a
+        # threaded context.
+        #
+        # Without the lock the tests start to fail of retring to
+        # delete the same key. This could be the case if two
+        # threads having differents copies of the keys tries to
+        # unregister the same key.
+        self._register_lock = threading.Lock()
+
+    def __len__(self):
+        return len(self._selector_keys)
+
+    def __iter__(self):
+        """Return an interator over a copy of the active SelectorKeys.
+
+        Specifically we use a copy to be able to freely use
+        `register` and `unregister` while iterating over the keys.
+
+        The underlying Selectors instance doesn't provide a public
+        mapping that can be copied without iterating all over
+        the values because it implements the Mapping interface from two
+        underlying dicts.
+        """
+        with self._register_lock:
+            keys = self._selector_keys.copy()
+        return iter(keys)
+
+    @property
+    def connections(self):
+        # no need to lock, self.__iter__ already does that
+        # before the copy
+        return (sk.data for sk in self)
+
+    def register(self, fileobj, events, data=None):
+        with self._register_lock:
+            key = self._selector.register(fileobj, events, data)
+            self._selector_keys.add(key)
+
+    def unregister(self, fileobj):
+        with self._register_lock:
+            key = self._selector.unregister(fileobj)
+            self._selector_keys.remove(key)
+
+    def select(self, timeout=None):
+        """Return a list of the connections with events in the form:
+        (connection, socket_file_descriptor)
+        """
+        return [
+            (key.data, key.fd)
+            for key, _ in self._selector.select(timeout=timeout)
+        ]
+
+    def close(self):
+        self._selector.close()
+
+
 class ConnectionManager:
     """Class which manages HTTPConnection objects.
 
@@ -64,11 +142,11 @@ class ConnectionManager:
         """
         self.server = server
         self._readable_conns = collections.deque()
-        self._selector = selectors.DefaultSelector()
-
-        self._selector.register(
+        self._selector_mgr = _SelectorManager()
+        self._selector_mgr.register(
             server.socket.fileno(),
-            selectors.EVENT_READ, data=server,
+            selectors.EVENT_READ,
+            data=server
         )
 
     def put(self, conn):
@@ -84,7 +162,7 @@ class ConnectionManager:
         if conn.rfile.has_data():
             self._readable_conns.append(conn)
         else:
-            self._selector.register(
+            self._selector_mgr.register(
                 conn.socket.fileno(), selectors.EVENT_READ, data=conn,
             )
 
@@ -99,15 +177,10 @@ class ConnectionManager:
         # find any connections still registered with the selector
         # that have not been active recently enough.
         threshold = time.time() - self.server.timeout
-        timed_out_connections = [
-            (sock_fd, conn)
-            for _, (_, sock_fd, _, conn)
-            in self._selector.get_map().items()
-            if conn != self.server and conn.last_used < threshold
-        ]
-        for sock_fd, conn in timed_out_connections:
-            self._selector.unregister(sock_fd)
-            conn.close()
+        for (_, sock_fd, _, conn) in self._selector_mgr:
+            if conn is not self.server and conn.last_used < threshold:
+                self._selector_mgr.unregister(sock_fd)
+                conn.close()
 
     def get_conn(self):  # noqa: C901  # FIXME
         """Return a HTTPConnection object which is ready to be handled.
@@ -132,40 +205,33 @@ class ConnectionManager:
             # The timeout value impacts performance and should be carefully
             # chosen. Ref:
             # github.com/cherrypy/cheroot/issues/305#issuecomment-663985165
-            rlist = [
-                key for key, _
-                in self._selector.select(timeout=0.01)
-            ]
+            conn_ready_list = self._selector_mgr.select(timeout=0.01)
         except OSError:
             # Mark any connection which no longer appears valid
-            invalid_entries = []
-            for _, key in self._selector.get_map().items():
+            for (_, sock_fd, _, conn) in self._selector_mgr:
                 # If the server socket is invalid, we'll just ignore it and
                 # wait to be shutdown.
-                if key.data == self.server:
+                if conn is self.server:
                     continue
 
                 try:
-                    os.fstat(key.fd)
+                    os.fstat(sock_fd)
                 except OSError:
-                    invalid_entries.append((key.fd, key.data))
-
-            for sock_fd, conn in invalid_entries:
-                self._selector.unregister(sock_fd)
-                conn.close()
+                    # Unregister and close all the invalid connections.
+                    self._selector_mgr.unregister(sock_fd)
+                    conn.close()
 
             # Wait for the next tick to occur.
             return None
 
-        for key in rlist:
-            if key.data is self.server:
+        for (conn, sock_fd) in conn_ready_list:
+            if conn is self.server:
                 # New connection
                 return self._from_server_socket(self.server.socket)
 
-            conn = key.data
             # unregister connection from the selector until the server
             # has read from it and returned it via put()
-            self._selector.unregister(key.fd)
+            self._selector_mgr.unregister(sock_fd)
             self._readable_conns.append(conn)
 
         try:
@@ -268,12 +334,12 @@ class ConnectionManager:
         for conn in self._readable_conns:
             conn.close()
         self._readable_conns.clear()
+        for conn in self._selector_mgr.connections:
+            # Server closes its own socket.
+            if conn is not self.server:
+                conn.socket.close()
 
-        for _, key in self._selector.get_map().items():
-            if key.data != self.server:  # server closes its own socket
-                key.data.socket.close()
-
-        self._selector.close()
+        self._selector_mgr.close()
 
     @property
     def _num_connections(self):
@@ -283,7 +349,7 @@ class ConnectionManager:
         minus one for the server socket, which is always registered
         with the selector.
         """
-        return len(self._readable_conns) + len(self._selector.get_map()) - 1
+        return len(self._readable_conns) + len(self._selector_mgr) - 1
 
     @property
     def can_add_keepalive_connection(self):

--- a/cheroot/connections.py
+++ b/cheroot/connections.py
@@ -102,8 +102,10 @@ class _SelectorManager:
             self._selector_keys.remove(key)
 
     def select(self, timeout=None):
-        """Return a list of the connections with events in the form:
-        (connection, socket_file_descriptor)
+        """Wrap the selectors.select call.
+
+        Returns a list of the connections with events in the form:
+            (connection, socket_file_descriptor)
         """
         return [
             (key.data, key.fd)
@@ -133,7 +135,7 @@ class ConnectionManager:
         self._selector_mgr.register(
             server.socket.fileno(),
             selectors.EVENT_READ,
-            data=server
+            data=server,
         )
 
     def put(self, conn):

--- a/cheroot/server.py
+++ b/cheroot/server.py
@@ -1797,6 +1797,9 @@ class HTTPServer:
             try:
                 self.tick()
             except (KeyboardInterrupt, SystemExit):
+                # Set self.serving to False, otherwise: safe_start() -> stop()
+                # will be blocked and never end gracefully.
+                self.serving = False
                 raise
             except Exception:
                 self.error_log(

--- a/cheroot/test/conftest.py
+++ b/cheroot/test/conftest.py
@@ -16,19 +16,33 @@ from ..server import Gateway, HTTPServer
 from ..testing import (  # noqa: F401
     native_server, wsgi_server,
 )
-from ..testing import get_server_client
+from ..testing import get_server_client, ErrorLogMonitor
 
 
 @pytest.fixture
-def wsgi_server_client(wsgi_server):  # noqa: F811
-    """Create a test client out of given WSGI server."""
-    return get_server_client(wsgi_server)
+def wsgi_server_client(wsgi_server, monkeypatch):  # noqa: F811
+    """Create a test client out of given WSGI server.
+
+    If you need to ignore a particular error message use the property
+    ``error_log.ignored_msgs`` by appending to the list
+    the expected error messages.
+    """
+    monkeypatch.setattr(wsgi_server, 'error_log', ErrorLogMonitor())
+    yield get_server_client(wsgi_server)
+    wsgi_server.error_log._teardown_verification()
 
 
 @pytest.fixture
-def native_server_client(native_server):  # noqa: F811
-    """Create a test client out of given HTTP server."""
-    return get_server_client(native_server)
+def native_server_client(native_server, monkeypatch):  # noqa: F811
+    """Create a test client out of given HTTP server.
+
+    If you need to ignore a particular error message use the property
+    ``error_log.ignored_msgs`` by appending to the list
+    the expected error messages.
+    """
+    monkeypatch.setattr(native_server, 'error_log', ErrorLogMonitor())
+    yield get_server_client(native_server)
+    native_server.error_log._teardown_verification()
 
 
 @pytest.fixture

--- a/cheroot/test/test_conn.py
+++ b/cheroot/test/test_conn.py
@@ -1013,15 +1013,10 @@ def test_No_CRLF(test_client, invalid_terminator):
 
 
 class FaultySelectorManager:
-    """Mock class to insert errors in th execution.
-
-    Wraps: :py:class:`!cheroot.connections._SelectorManager`.
-    """
+    """Mock class to insert errors in th execution."""
 
     def __init__(self, orig_select_mgr):
         """Prepare the wrapper to intervene the execution.
-
-        Wraps: :py:class:`!cheroot.connections._SelectorManager`.
 
         Initialize the flags to trigger the errors inside the
         _SelectorManager to put to test the error handling segments
@@ -1051,7 +1046,7 @@ class FaultySelectorManager:
         return len(self.orig_select_mgr)
 
     def __iter__(self):
-        """Intercept the calls to _SelectorManager iterator."""
+        """Intercept the calls to the iterator."""
         result = tuple(self.orig_select_mgr)
         sabotage_targets = (
             conn for _, _, _, conn in result
@@ -1067,7 +1062,7 @@ class FaultySelectorManager:
         return iter(result)
 
     def select(self, timeout):
-        """Intercept the calls to `:py:meth:!_SelectorManager.select`."""
+        """Intercept the select call."""
         if self.request_served:
             self.os_error_triggered = True
             raise OSError('Error while selecting the client socket.')

--- a/cheroot/test/test_conn.py
+++ b/cheroot/test/test_conn.py
@@ -1013,17 +1013,22 @@ def test_No_CRLF(test_client, invalid_terminator):
 
 
 class FaultySelectorManager:
-    """Mock class to insert errors in a `_SelectorManager`."""
+    """Mock class to insert errors in th execution.
+
+    Wraps: `cheroot.connections._SelectorManager`.
+    """
 
     def __init__(self, orig_select_mgr):
-        """Prepare wrapper of `_SelectorManager` to intervene the execution.
+        """Prepare the wrapper to intervene the execution.
+
+        Wraps: `cheroot.connections._SelectorManager`.
 
         Initialize the flags to trigger the errors inside the
-        `_SelectorManager` to put to test the error handling segments
-        of `ConnectionManager`.
+        _SelectorManager to put to test the error handling segments
+        of ConnectionManager.
 
         This class is heavily dependent on the implementation of
-        `_SelectorManager` and `ConnectionManager`, be ready to refactor
+        _SelectorManager and ConnectionManager, be ready to refactor
         and adjust if the integration between those two changes.
         """
         # reference to the good instance

--- a/cheroot/test/test_conn.py
+++ b/cheroot/test/test_conn.py
@@ -68,7 +68,7 @@ class Controller(helper.Controller):
 
     def one_megabyte_of_a(req, resp):
         """Render 1MB response."""
-        return ['a' * 1024] * 1024
+        return 'a' * 1024 * 1024
 
     def wrong_cl_buffered(req, resp):
         """Render buffered response with invalid length value."""
@@ -963,12 +963,11 @@ def test_Content_Length_out(
     ))
 
 
-@pytest.mark.xfail(
-    reason='Sometimes this test fails due to low timeout. '
-           'Ref: https://github.com/cherrypy/cherrypy/issues/598',
-)
 def test_598(test_client):
-    """Test serving large file with a read timeout in place."""
+    """Test serving large file with a read timeout in place.
+
+    Ref: https://github.com/cherrypy/cherrypy/issues/598
+    """
     # Initialize a persistent HTTP connection
     conn = test_client.get_connection()
     remote_data_conn = urllib.request.urlopen(

--- a/cheroot/test/test_conn.py
+++ b/cheroot/test/test_conn.py
@@ -1015,13 +1015,13 @@ def test_No_CRLF(test_client, invalid_terminator):
 class FaultySelectorManager:
     """Mock class to insert errors in th execution.
 
-    Wraps: cheroot.connections._SelectorManager.
+    Wraps: :py:class:`!cheroot.connections._SelectorManager`.
     """
 
     def __init__(self, orig_select_mgr):
         """Prepare the wrapper to intervene the execution.
 
-        Wraps: cheroot.connections._SelectorManager.
+        Wraps: :py:class:`!cheroot.connections._SelectorManager`.
 
         Initialize the flags to trigger the errors inside the
         _SelectorManager to put to test the error handling segments
@@ -1067,7 +1067,7 @@ class FaultySelectorManager:
         return iter(result)
 
     def select(self, timeout):
-        """Intercept the calls to _SelectorManager.select."""
+        """Intercept the calls to `:py:meth:!_SelectorManager.select`."""
         if self.request_served:
             self.os_error_triggered = True
             raise OSError('Error while selecting the client socket.')

--- a/cheroot/test/test_conn.py
+++ b/cheroot/test/test_conn.py
@@ -1015,13 +1015,13 @@ def test_No_CRLF(test_client, invalid_terminator):
 class FaultySelectorManager:
     """Mock class to insert errors in th execution.
 
-    Wraps: `cheroot.connections._SelectorManager`.
+    Wraps: cheroot.connections._SelectorManager.
     """
 
     def __init__(self, orig_select_mgr):
         """Prepare the wrapper to intervene the execution.
 
-        Wraps: `cheroot.connections._SelectorManager`.
+        Wraps: cheroot.connections._SelectorManager.
 
         Initialize the flags to trigger the errors inside the
         _SelectorManager to put to test the error handling segments

--- a/cheroot/test/test_conn.py
+++ b/cheroot/test/test_conn.py
@@ -1017,11 +1017,15 @@ class FaultySelectorManager:
     """Mock class to insert errors in the selector.get_map method."""
 
     def __init__(self, orig_select_mgr):
+        """Mock the connections._SelectorManager to intervene the execution."""
         self.orig_select_mgr = orig_select_mgr
+        # flag to trigger a fault on the iteration of connections
         self.sabotage_conn = False
+        # flag that marks when the explicit closing has been done
         self.conn_closed = False
-        # flags for select intervention
+        # flag to trigger the fault in the select call
         self.request_served = False
+        # flog to notify that the error has been rised for the select call
         self.os_error_triggered = False
 
     def __getattr__(self, attr):


### PR DESCRIPTION
❓ **What kind of change does this PR introduce?**
  - [x] 🐞 bug fix
  - [ ] 🐣 feature
  - [ ] 📋 docs update
  - [x] 📋 tests/coverage improvement
  - [x] 📋 refactoring
  - [ ] 💥 other

📋 **What is the related issue number (starting with `#`)**

#317 

❓ **What is the current behavior?** (You can also link to an open issue here)

There is a race condition between the internal server `tick()` method to expire connections and the
worker threads that can modify the underlying sockets to be selected, while is been iterating over
by the expire method of `ConnectionManager`.

❓ **What is the new behavior (if this is a feature change)?**
Limits the access methods that could  modify the underlying sockets/fd that are been selected by the
`selectors.DefaultSelector` by having a write lock. An indirection layer that will guarantee consistency
between thread at the cost of a little overhead.

📋 **Other information**:

This locking approach could be temporary in case that we refactor the whole use of `selectors`, `ConnectionManager`
and `Server`.

Additionally: 
 - this PR expands the use of the `ErrorLogManager` helper test class, now is also used by `test_wsgi`, this test module
seems to be extensive enough to trigger some of the errors that were reported in issue #60 
- remove the `xfail` mark in one test that seems that it wasn't failing after all, it just wasn't returning the right value the test wsgi app.
- remove the py2 exception to tolerate the serve error_log messages, it was covering an issue in the different ways that `Server` closes the connections, for py2 it closed directly the OS socket, given the comment that was in that segment (from around 12 years)  seems that the goal was to send the FIN packet, which can be accomplished by socket.shutdown, instead of relying in the OS by closing the file descriptor. (verified with linux/wireshark/pdb at localhost).

📋 **Checklist**:

  - [X] I think the code is well written
  - [X] I wrote [good commit messages][1]
  - [ ] I have [squashed related commits together][2] after the changes have been approved
  - [ ] Unit tests for the changes exist
  - [X] Integration tests for the changes exist (if applicable)
  - [X] I used the same coding conventions as the rest of the project
  - [X] The new code doesn't generate linter offenses
  - [ ] Documentation reflects the changes
  - [ ] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences

[1]: http://chris.beams.io/posts/git-commit/
[2]: https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cherrypy/cheroot/318)
<!-- Reviewable:end -->
