### PR TITLE
connections: put conns safely

### DIFF
--- a/cheroot/_compat.py
+++ b/cheroot/_compat.py
@@ -15,6 +15,14 @@ except ImportError:
     import selectors2 as selectors  # noqa: F401  # lgtm [py/unused-import]
 
 try:
+    from backports.socketpair import socket
+except ImportError:
+    import socket
+finally:
+    socketpair = socket.socketpair
+    del socket
+
+try:
     import ssl
     IS_ABOVE_OPENSSL10 = ssl.OPENSSL_VERSION_INFO >= (1, 1)
     del ssl

--- a/cheroot/server.py
+++ b/cheroot/server.py
@@ -1804,6 +1804,8 @@ class HTTPServer:
                     traceback=True,
                 )
 
+        # ensure self._connections is closed from the serve() thread.
+        self._connections.close()
         self.serving = False
 
     def start(self):
@@ -2111,7 +2113,6 @@ class HTTPServer:
                 sock.close()
             self.socket = None
 
-        self._connections.close()
         self.requests.stop(self.shutdown_timeout)
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -65,6 +65,7 @@ setup_requires =
 # These are required in actual runtime:
 install_requires =
     backports.functools_lru_cache; python_version < '3.3'
+    backports.socketpair; python_version < '3.5'
     selectors2; python_version< '3.4'
     six>=1.11.0
     more_itertools>=2.6


### PR DESCRIPTION
❓ **What kind of change does this PR introduce?**
  - [x] 🐞 bug fix
  - [ ] 🐣 feature
  - [ ] 📋 docs update
  - [ ] 📋 tests/coverage improvement
  - [ ] 📋 refactoring
  - [ ] 💥 other

📋 **What is the related issue number (starting with `#`)**

Fixes #317

❓ **What is the current behavior?** (You can also link to an open issue here)

seeing errors while iterating over the map of connections within the selector in the event that a `put()` call overlaps an `expire()` call

❓ **What is the new behavior (if this is a feature change)?**

instead of registering sockets with the selector from other threads, ensure they're registered from within the thread running the selector.

📋 **Other information**:

This introduces https://pypi.org/project/backports.socketpair in order to provide a pure-python implementation of `socket.socketpair()` for platforms that don't have have it, prior to python 3.5+.

We could possibly use some of the enhanced tests from https://github.com/cherrypy/cheroot/pull/318 to validate

📋 **Checklist**:

  - [x] I think the code is well written
  - [x] I wrote [good commit messages][1]
  - [ ] I have [squashed related commits together][2] after the changes have been approved
  - [ ] Unit tests for the changes exist
  - [ ] Integration tests for the changes exist (if applicable)
  - [x] I used the same coding conventions as the rest of the project
  - [x] The new code doesn't generate linter offenses
  - [x] Documentation reflects the changes
  - [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences

[1]: http://chris.beams.io/posts/git-commit/
[2]: https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cherrypy/cheroot/319)
<!-- Reviewable:end -->
