### PR TITLE
Fix dict modified during iteration error

### DIFF
--- a/cheroot/connections.py
+++ b/cheroot/connections.py
@@ -105,7 +105,7 @@ class ConnectionManager:
             in self._selector.get_map().items()
             if conn != self.server and conn.last_used < threshold
         ]
-        for sock_fd, conn in timed_out_connections:
+        for sock_fd, conn in list(timed_out_connections):
             self._selector.unregister(sock_fd)
             conn.close()
 


### PR DESCRIPTION
ERROR:cherrypy.error:[31/Aug/2020:11:49:09] ENGINE Error in HTTPServer.tick
Traceback (most recent call last):
  File "/home/resi/pedersen/workspace/venvs/sampletracker3/lib/python3.6/site-packages/cheroot/server.py", line 1795, in serve
    self.tick()
  File "/home/resi/pedersen/workspace/venvs/sampletracker3/lib/python3.6/site-packages/cheroot/server.py", line 2030, in tick
    self.connections.expire()
  File "/home/resi/pedersen/workspace/venvs/sampletracker3/lib/python3.6/site-packages/cheroot/connections.py", line 107, in expire
    for sock_fd, conn in timed_out_connections:
  File "/home/resi/pedersen/workspace/venvs/sampletracker3/lib/python3.6/site-packages/cheroot/connections.py", line 103, in <genexpr>
    (sock_fd, conn)
  File "/usr/lib/python3.6/_collections_abc.py", line 743, in __iter__
    for key in self._mapping:
RuntimeError: dictionary changed size during iteration

❓ **What kind of change does this PR introduce?**
  - [ X] 🐞 bug fix
  - [ ] 🐣 feature
  - [ ] 📋 docs update
  - [ ] 📋 tests/coverage improvement
  - [ ] 📋 refactoring
  - [ ] 💥 other

📋 **What is the related issue number (starting with `#`)**

#317



📋 **Checklist**:

  - [ x] I think the code is well written
  - [ ] I wrote [good commit messages][1]
  - [ ] I have [squashed related commits together][2] after the changes have been approved
  - [ ] Unit tests for the changes exist
  - [ ] Integration tests for the changes exist (if applicable)
  - [ ] I used the same coding conventions as the rest of the project
  - [ ] The new code doesn't generate linter offenses
  - [ ] Documentation reflects the changes
  - [ ] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences

[1]: http://chris.beams.io/posts/git-commit/
[2]: https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cherrypy/cheroot/320)
<!-- Reviewable:end -->
