### PR TITLE
connections: add threadsafe selector wrapper

### DIFF
--- a/cheroot/connections.py
+++ b/cheroot/connections.py
@@ -220,7 +220,12 @@ class ConnectionManager:
 
         for sock_fd, conn in invalid_conns:
             self._selector.unregister(sock_fd)
-            conn.close()
+            # One of the reason on why a socket could cause an error
+            # is that the socket is already closed, ignore the
+            # socket error if we try to close it at this point.
+            # This is equivalent to OSError in Py3
+            with suppress(socket.error):
+                conn.close()
 
     def _from_server_socket(self, server_socket):  # noqa: C901  # FIXME
         try:

--- a/cheroot/server.py
+++ b/cheroot/server.py
@@ -74,6 +74,7 @@ import logging
 import platform
 import contextlib
 import threading
+import errno
 
 try:
     from functools import lru_cache
@@ -1350,7 +1351,25 @@ class HTTPConnection:
         self.rfile.close()
 
         if not self.linger:
-            self._close_kernel_socket()
+            try:
+                # Make sure we terminate the connection at the transport level.
+                if hasattr(self.socket, 'sock_shutdown'):
+                    # The special method sock_shutdown is used for
+                    # the PyOpenSSL connections that can could be used
+                    # as socket.
+                    self.socket.sock_shutdown(socket.SHUT_RDWR)
+                else:
+                    self.socket.shutdown(socket.SHUT_RDWR)
+            except socket.error as e:
+                # raise the error if the error is
+                # other than the client is no longer
+                # connected.
+                if e.errno != errno.ENOTCONN:
+                    raise e
+
+            # close the socket file descriptor
+            # (will be closed in the OS if there is no
+            # other reference to the underlying socket)
             self.socket.close()
         else:
             # On the other hand, sometimes we want to hang around for a bit
@@ -1460,20 +1479,6 @@ class HTTPConnection:
         """Return the group of the connected peer process."""
         _, group = self.resolve_peer_creds()
         return group
-
-    def _close_kernel_socket(self):
-        """Close kernel socket in outdated Python versions.
-
-        On old Python versions,
-        Python's socket module does NOT call close on the kernel
-        socket when you call socket.close(). We do so manually here
-        because we want this server to send a FIN TCP segment
-        immediately. Note this must be called *before* calling
-        socket.close(), because the latter drops its reference to
-        the kernel socket.
-        """
-        if six.PY2 and hasattr(self.socket, '_sock'):
-            self.socket._sock.close()
 
 
 class HTTPServer:

--- a/cheroot/test/conftest.py
+++ b/cheroot/test/conftest.py
@@ -12,21 +12,40 @@ import time
 
 import pytest
 
+import cheroot
+
 from ..server import Gateway, HTTPServer
-from ..testing import (  # noqa: F401
-    native_server, wsgi_server,
+from ..testing import (
+    check_log_messages,
+    cheroot_server,
+    get_server_client,
 )
-from ..testing import get_server_client
 
 
 @pytest.fixture
-def wsgi_server_client(wsgi_server):  # noqa: F811
+def wsgi_server(caplog):
+    """Set up and tear down a Cheroot WSGI server instance."""
+    for srv in cheroot_server(cheroot.wsgi.Server):
+        yield srv
+    check_log_messages(srv.ignored_log_msgs, caplog)
+
+
+@pytest.fixture
+def native_server(caplog):
+    """Set up and tear down a Cheroot HTTP server instance."""
+    for srv in cheroot_server(cheroot.server.HTTPServer):
+        yield srv
+    check_log_messages(srv.ignored_log_msgs, caplog)
+
+
+@pytest.fixture
+def wsgi_server_client(wsgi_server):
     """Create a test client out of given WSGI server."""
     return get_server_client(wsgi_server)
 
 
 @pytest.fixture
-def native_server_client(native_server):  # noqa: F811
+def native_server_client(native_server):
     """Create a test client out of given HTTP server."""
     return get_server_client(native_server)
 

--- a/cheroot/test/test_cli.py
+++ b/cheroot/test/test_cli.py
@@ -34,7 +34,7 @@ from cheroot.cli import (
 def test_parse_wsgi_bind_addr(raw_bind_addr, expected_bind_addr):
     """Check the parsing of the --bind option.
 
-    Verify some of the supported addresses and the excpected return value.
+    Verify some of the supported addresses and the expected return value.
     """
     assert parse_wsgi_bind_addr(raw_bind_addr) == expected_bind_addr
 

--- a/cheroot/test/test_conn.py
+++ b/cheroot/test/test_conn.py
@@ -5,9 +5,6 @@ __metaclass__ = type
 
 import socket
 import time
-import logging
-import traceback as traceback_
-from collections import namedtuple
 
 from six.moves import range, http_client, urllib
 
@@ -111,32 +108,8 @@ class Controller(helper.Controller):
     }
 
 
-class ErrorLogMonitor:
-    """Mock class to access the server error_log calls made by the server."""
-
-    ErrorLogCall = namedtuple('ErrorLogCall', ['msg', 'level', 'traceback'])
-
-    def __init__(self):
-        """Initialize the server error log monitor/interceptor.
-
-        If you need to ignore a particular error message use the property
-        ``ignored_msgs` by appending to the list the expected error messages.
-        """
-        self.calls = []
-        # to be used the the teardown validation
-        self.ignored_msgs = []
-
-    def __call__(self, msg='', level=logging.INFO, traceback=False):
-        """Intercept the call to the server error_log method."""
-        if traceback:
-            tblines = traceback_.format_exc()
-        else:
-            tblines = ''
-        self.calls.append(ErrorLogMonitor.ErrorLogCall(msg, level, tblines))
-
-
 @pytest.fixture
-def raw_testing_server(wsgi_server_client):
+def testing_server(wsgi_server_client):
     """Attach a WSGI app to the given server and preconfigure it."""
     app = Controller()
 
@@ -151,32 +124,6 @@ def raw_testing_server(wsgi_server_client):
     wsgi_server.keep_alive_conn_limit = 2
 
     return wsgi_server
-
-
-@pytest.fixture
-def testing_server(raw_testing_server, monkeypatch):
-    """Modify the "raw" base server to monitor the error_log messages.
-
-    If you need to ignore a particular error message use the property
-    ``testing_server.error_log.ignored_msgs`` by appending to the list
-    the expected error messages.
-    """
-    # patch the error_log calls of the server instance
-    monkeypatch.setattr(raw_testing_server, 'error_log', ErrorLogMonitor())
-
-    yield raw_testing_server
-
-    # Teardown verification, in case that the server logged an
-    # error that wasn't notified to the client or we just made a mistake.
-    for c_msg, c_level, c_traceback in raw_testing_server.error_log.calls:
-        if c_level <= logging.WARNING:
-            continue
-
-        assert c_msg in raw_testing_server.error_log.ignored_msgs, (
-            'Found error in the error log: '
-            "message = '{c_msg}', level = '{c_level}'\n"
-            '{c_traceback}'.format(**locals()),
-        )
 
 
 @pytest.fixture
@@ -1009,7 +956,7 @@ def test_Content_Length_out(
     # the server logs the exception that we had verified from the
     # client perspective. Tell the error_log verification that
     # it can ignore that message.
-    test_client.server_instance.error_log.ignored_msgs.extend((
+    test_client.server_instance.ignored_log_msgs.extend((
         # Python 3.7+:
         "ValueError('Response body exceeds the declared Content-Length.')",
         # Python 2.7-3.6 (macOS?):
@@ -1089,7 +1036,7 @@ class FaultyGetMap:
     """Mock class to insert errors in the selector.get_map method."""
 
     def __init__(self, original_get_map):
-        """Initilize helper class to wrap the selector.get_map method."""
+        """Initialize helper class to wrap the selector.get_map method."""
         self.original_get_map = original_get_map
         self.sabotage_conn = False
         self.socket_closed = False
@@ -1148,10 +1095,3 @@ def test_invalid_selected_connection(test_client, monkeypatch):
     time.sleep(0.2)
     assert faux_select.os_error_triggered
     assert faux_get_map.socket_closed
-    # any error in the error handling should be catched by the
-    # teardown verification for the error_log
-
-    if six.PY2:
-        test_client.server_instance.error_log.ignored_msgs.append(
-            'Error in HTTPServer.tick',
-        )

--- a/cheroot/test/test_conn.py
+++ b/cheroot/test/test_conn.py
@@ -1073,11 +1073,11 @@ def test_invalid_selected_connection(test_client, monkeypatch):
 
     # patch the get_map method
     faux_get_map = FaultyGetMap(
-        test_client.server_instance._connections._selector.get_map,
+        test_client.server_instance._connections._selector._selector.get_map,
     )
 
     monkeypatch.setattr(
-        test_client.server_instance._connections._selector,
+        test_client.server_instance._connections._selector._selector,
         'get_map',
         faux_get_map,
     )

--- a/cheroot/test/test_core.py
+++ b/cheroot/test/test_core.py
@@ -6,7 +6,6 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 import errno
-import os
 import socket
 
 import pytest
@@ -14,9 +13,6 @@ import six
 from six.moves import urllib
 
 from cheroot.test import helper
-
-
-IS_CIRCLE_CI_ENV = 'CIRCLECI' in os.environ
 
 
 HTTP_BAD_REQUEST = 400
@@ -283,7 +279,6 @@ def test_content_length_required(test_client):
 
 
 @pytest.mark.xfail(
-    IS_CIRCLE_CI_ENV,
     reason='https://github.com/cherrypy/cheroot/issues/106',
     strict=False,  # sometimes it passes
 )


### PR DESCRIPTION
❓ **What kind of change does this PR introduce?**
  - [x] 🐞 bug fix
  - [ ] 🐣 feature
  - [ ] 📋 docs update
  - [ ] 📋 tests/coverage improvement
  - [ ] 📋 refactoring
  - [ ] 💥 other

📋 **What is the related issue number (starting with `#`)**

#317

❓ **What is the current behavior?** (You can also link to an open issue here)

The selector can be modified from thread pool threads, so can 

❓ **What is the new behavior (if this is a feature change)?**

Adds a thread safe wrapper for the selector.

This is an alternative to #319, and is inspired by #318 but does not go as far as copying all connections, and instead only locks around access to the selector. This avoids adding a new dependency, and the implementation is simpler.

I still think #318 is also a reasonable approach, but it's not necessary to copy the connections, since the fundamental error is accessing the selector in different threads, as opposed to the connections themselves.

📋 **Other information**:

This also modifies the server to use the stdlib logger, such that we can use the pytest caplog fixture to capture and assert on the validity of log messages, which replaces the existing `ErrorLogMonitor` monkeypatch.

This also increases the scope in which these teardown verifications are done - previously it was only within test_conn, but this now effectively covers all tests.

I am open to keeping the existing `ErrorLogMonitor` implementation if that's preferable, but my assumption was that using the standard logger and pytest caplog infra, rather than a custom implementation, were worth it.

📋 **Checklist**:

  - [x] I think the code is well written
  - [x] I wrote [good commit messages][1]
  - [x] I have [squashed related commits together][2] after the changes have been approved
  - [x] Unit tests for the changes exist
  - [x] Integration tests for the changes exist (if applicable)
  - [x] I used the same coding conventions as the rest of the project
  - [x] The new code doesn't generate linter offenses
  - [x] Documentation reflects the changes
  - [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences

[1]: http://chris.beams.io/posts/git-commit/
[2]: https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cherrypy/cheroot/325)
<!-- Reviewable:end -->
