### PR TITLE
Correctly stop server on Ctrl-C

### DIFF
--- a/cheroot/connections.py
+++ b/cheroot/connections.py
@@ -267,9 +267,13 @@ class ConnectionManager:
             conn.close()
         self._readable_conns.clear()
 
-        for _, key in self._selector.get_map().items():
-            if key.data != self.server:  # server closes its own socket
-                key.data.socket.close()
+        connections = (
+            conn.data.socket
+            for _, conn in (self._selector.get_map() or {}).items()
+            if conn.data != self.server  # server closes its own socket
+        )
+        for connection in connections:
+            connection.close()
 
         self._selector.close()
 

--- a/cheroot/server.py
+++ b/cheroot/server.py
@@ -1797,6 +1797,7 @@ class HTTPServer:
             try:
                 self.tick()
             except (KeyboardInterrupt, SystemExit):
+                self.serving = False
                 raise
             except Exception:
                 self.error_log(


### PR DESCRIPTION
❓ **What kind of change does this PR introduce?**
  - [x] 🐞 bug fix
  - [ ] 🐣 feature
  - [ ] 📋 docs update
  - [ ] 📋 tests/coverage improvement
  - [ ] 📋 refactoring
  - [ ] 💥 other

📋 **What is the related issue number (starting with `#`)**

Fixes #328
Fixes cherrypy/cherrypy#1873

❓ **What is the current behavior?** (You can also link to an open issue here)
Ctrl-C hangs on "Keyboard interrupt: shutting down"


❓ **What is the new behavior (if this is a feature change)?**
`serve` returns on Ctrl-C


📋 **Other information**:
There was another PR at https://github.com/cherrypy/cheroot/pull/322 that I found after implementing this. My PR also adds a `None` check around a call to `selectors.map`. Without it, I get a `None` access on Ctrl-C instead.

I don't know how to write an automated test for this given that it only touches Ctrl-C behaviour. It's very easy to see the behaviour change though:

```python
from cheroot.wsgi import Server


def app(*args, **kwargs):
    return None


if __name__ == "__main__":
    server = Server(bind_addr=("localhost", 1234), wsgi_app=app)
    try:
        server.safe_start()
    except KeyboardInterrupt:
        print("keyboard interrupt")
    server.stop()  # Hangs forever.
```

This currently hangs at `Keyboard interrupt: shutting down`. After this PR it exists right away.


📋 **Checklist**:

  - [x] I think the code is well written
  - [x] I wrote [good commit messages][1]
  - [x] I have [squashed related commits together][2] after the changes have been approved
  - [x] Unit tests for the changes exist
  - [ ] Integration tests for the changes exist (if applicable)
  - [x] I used the same coding conventions as the rest of the project
  - [x] The new code doesn't generate linter offenses
  - [ ] Documentation reflects the changes
  - [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences

[1]: http://chris.beams.io/posts/git-commit/
[2]: https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cherrypy/cheroot/331)
<!-- Reviewable:end -->
