### PR TITLE
avoid tracebacks / ignore errors from too low version SSL clients

### DIFF
--- a/cheroot/ssl/builtin.py
+++ b/cheroot/ssl/builtin.py
@@ -299,6 +299,8 @@ class BuiltinSSLAdapter(Adapter):
                     'no shared cipher', 'certificate unknown',
                     'ccs received early',
                     'certificate verify failed',  # client cert w/o trusted CA
+                    'version too low', # caused by SSL3 connections
+                    'unsupported protocol', # caused by TLS1 connections
                 )
                 if _assert_ssl_exc_contains(ex, *_block_errors):
                     # Accepted error, let's pass


### PR DESCRIPTION
with help by @Safihre

❓ **What kind of change does this PR introduce?**
  - [x] 🐞 bug fix
  - [ ] 🐣 feature
  - [ ] 📋 docs update
  - [ ] 📋 tests/coverage improvement
  - [ ] 📋 refactoring
  - [ ] 💥 other

📋 **What is the related issue number (starting with `#`)**


#292 

❓ **What is the current behavior?** (You can also link to an open issue here)



A TLSv1 connection like
`echo | ~/git/testssl.sh/bin/openssl.Linux.x86_64 s_client -connect 127.0.0.1:8080 -tls1  2>&1`
gives
```
2020-11-14 12:07:56,135::INFO::[notifier:122] Sending notification: Error - [14/Nov/2020:12:07:56] ENGINE Error in HTTPServer.tick
Traceback (most recent call last):
  File "/home/sander/.local/lib/python3.8/site-packages/cheroot/server.py", line 1788, in serve
    self.tick()
  File "/home/sander/.local/lib/python3.8/site-packages/cheroot/server.py", line 2023, in tick
    conn = self.connections.get_conn(self.socket)
  File "/home/sander/.local/lib/python3.8/site-packages/cheroot/connections.py", line 188, in get_conn
    return self._from_server_socket(server_socket)
  File "/home/sander/.local/lib/python3.8/site-packages/cheroot/connections.py", line 207, in _from_server_socket
    s, ssl_env = self.server.ssl_adapter.wrap(s)
  File "/home/sander/.local/lib/python3.8/site-packages/cheroot/ssl/builtin.py", line 277, in wrap
    s = self.context.wrap_socket(
  File "/usr/lib/python3.8/ssl.py", line 500, in wrap_socket
    return self.sslsocket_class._create(
  File "/usr/lib/python3.8/ssl.py", line 1040, in _create
    self.do_handshake()
  File "/usr/lib/python3.8/ssl.py", line 1309, in do_handshake
    self._sslobj.do_handshake()
ssl.SSLError: [SSL: UNSUPPORTED_PROTOCOL] unsupported protocol (_ssl.c:1123)

```
and a SSLv3 connection like
`echo | ~/git/testssl.sh/bin/openssl.Linux.x86_64 s_client -connect 127.0.0.1:8080 -ssl3  2>&1`
gives
```
2020-11-14 12:08:23,233::INFO::[notifier:122] Sending notification: Error - [14/Nov/2020:12:08:23] ENGINE Error in HTTPServer.tick
Traceback (most recent call last):
  File "/home/sander/.local/lib/python3.8/site-packages/cheroot/server.py", line 1788, in serve
    self.tick()
  File "/home/sander/.local/lib/python3.8/site-packages/cheroot/server.py", line 2023, in tick
    conn = self.connections.get_conn(self.socket)
  File "/home/sander/.local/lib/python3.8/site-packages/cheroot/connections.py", line 188, in get_conn
    return self._from_server_socket(server_socket)
  File "/home/sander/.local/lib/python3.8/site-packages/cheroot/connections.py", line 207, in _from_server_socket
    s, ssl_env = self.server.ssl_adapter.wrap(s)
  File "/home/sander/.local/lib/python3.8/site-packages/cheroot/ssl/builtin.py", line 277, in wrap
    s = self.context.wrap_socket(
  File "/usr/lib/python3.8/ssl.py", line 500, in wrap_socket
    return self.sslsocket_class._create(
  File "/usr/lib/python3.8/ssl.py", line 1040, in _create
    self.do_handshake()
  File "/usr/lib/python3.8/ssl.py", line 1309, in do_handshake
    self._sslobj.do_handshake()
ssl.SSLError: [SSL: VERSION_TOO_LOW] version too low (_ssl.c:1123)

```

❓ **What is the new behavior (if this is a feature change)?**

No more traceback

📋 **Other information**:



📋 **Checklist**:

  - [ ] I think the code is well written
  - [ ] I wrote [good commit messages][1]
  - [ ] I have [squashed related commits together][2] after the changes have been approved
  - [ ] Unit tests for the changes exist
  - [ ] Integration tests for the changes exist (if applicable)
  - [ ] I used the same coding conventions as the rest of the project
  - [ ] The new code doesn't generate linter offenses
  - [ ] Documentation reflects the changes
  - [ ] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences

[1]: http://chris.beams.io/posts/git-commit/
[2]: https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cherrypy/cheroot/334)
<!-- Reviewable:end -->
