### PR TITLE
Drop macOS jobs from Travis CI setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,147 +10,19 @@ python:
 - 3.6
 - &pypy3 pypy3
 
-env:
-  global:
-    GIT_INSTALLER_DIR_PATH: ${HOME}/.git-installers
-    GIT_VERSION: 2.20.1
-    PYTHON_INSTALLER_DIR_PATH: ${HOME}/.python-installers
-
 _base_envs:
 - &stage_lint
   stage: &stage_lint_name lint
-- &stage_test
-  stage: &stage_test_name test
 - &stage_test_priority
   stage: &stage_test_priority_name test against latest Python versions first (under GNU/Linux)
-- &stage_test_osx
-  stage: &stage_test_osx_name test under OS X (last chance to fail before deploy available)
 - &stage_deploy
   stage: &stage_deploy_name upload new version of python package to PYPI (only for tagged commits)
 - &manual_run_or_cron  # run the job only if it's a cron run or it's triggered manually
   if: type IN (api, cron)
-- &pyenv_base
-  <<: *stage_test
-  language: generic
-  python: &pypy2 pypy
-  env:
-  - &env_pypy2 PYTHON_VERSION=pypy2.7-7.1.0
-  - &env_pyenv PYENV_ROOT="$HOME/.pyenv"
-  - &env_path PATH="$PYENV_ROOT/bin:$PATH"
-  before_install:
-  - &ensure_pyenv_installed |
-    if [ ! -f "$PYENV_ROOT/bin/pyenv" ]
-    then
-      rm -rf "$PYENV_ROOT"
-      curl -L https://raw.githubusercontent.com/pyenv/pyenv-installer/master/bin/pyenv-installer | bash
-    fi
-    eval "$(pyenv init -)"
-    eval "$(pyenv virtualenv-init -)"
-    pyenv update
-  - &install_python pyenv install --skip-existing --keep --verbose "$PYTHON_VERSION"
-  - &switch_python pyenv shell "$PYTHON_VERSION"
-  - &python_version python --version
-  - &python_ssl_openssl_version >-
-    python -c 'import ssl; print("\nOPENSSL_VERSION: " + ssl.OPENSSL_VERSION + "\nOPENSSL_VERSION_INFO: " + repr(ssl.OPENSSL_VERSION_INFO) + "\nOPENSSL_VERSION_NUMBER: " + repr(ssl.OPENSSL_VERSION_NUMBER))'
-- &osx_python_base
-  <<: *pyenv_base
-  <<: *stage_test_osx
-  os: osx
-  osx_image: xcode8.3
-  language: generic
-  cache:
-    directories:
-    - $HOME/Library/Caches/Homebrew
-    - $PYTHON_INSTALLER_DIR_PATH
-    - $GIT_INSTALLER_DIR_PATH
-  before_install: &install-from-pyenv
-  - brew install zlib readline
-  - brew install https://raw.githubusercontent.com/Homebrew/homebrew-core/master/Formula/pyenv.rb || brew upgrade pyenv
-  - brew install openssl@1.1
-  - &ensure_pyenv_preloaded |
-    eval "$(pyenv init -)"
-    eval "$(pyenv virtualenv-init -)"
-  - *install_python
-  - *switch_python
-  - *python_version
-  - python -m pip install --upgrade virtualenv
-  - python -m pip install tox
-  - env CRYPTOGRAPHY_SUPPRESS_LINK_FLAGS=1 LDFLAGS="$(brew --prefix openssl@1.1)/lib/libssl.a $(brew --prefix openssl@1.1)/lib/libcrypto.a" CFLAGS="-I$(brew --prefix openssl@1.1)/include" python -m tox --notest
-  - *python_ssl_openssl_version
-  before_install: &install-from-python_org
-  - |
-    function probe_url() {
-      local py_ver="$1"
-      [ $(curl -I --write-out '%{http_code}' --silent --output /dev/null "https://www.python.org/ftp/python/${py_ver}/python-${py_ver}-macosx10.6.pkg") == '200' ] && return 0
-      return 1
-    }
-  - |
-    function find_last_macos_py() {
-    for py_ver in $*
-    do
-      >&2 echo Probing $py_ver
-      probe_url $py_ver && >&2 echo "Found pkg: ${py_ver}" && echo $py_ver && return 0
-    done
-    >&2 echo Failed looking up macOS pkg for $*
-    return 1
-    }
-  - export GIT_DMG_NAME="git-${GIT_VERSION}-intel-universal-mavericks.dmg"
-  - export GIT_PKG_NAME="git-${GIT_VERSION}-intel-universal-mavericks.pkg"
-  - export GIT_DMG_PATH="${GIT_INSTALLER_DIR_PATH}/${GIT_DMG_NAME}"
-  - >
-    stat "${GIT_DMG_PATH}" &>/dev/null || wget -O "${GIT_DMG_PATH}" "https://sourceforge.net/projects/git-osx-installer/files/${GIT_DMG_NAME}/download?use_mirror=autoselect"
-  - stat "${GIT_DMG_PATH}" >/dev/null
-  - sudo hdiutil attach ${GIT_DMG_PATH}
-  - hdiutil info
-  - >
-    export GIT_INSTALLER_VOLUME=$(hdiutil info | tail -n1 | sed 's#^.*\(/Volumes.*\)#\1#')
-  - >
-    export GIT_INSTALLER_PATH="${GIT_INSTALLER_VOLUME}/${GIT_PKG_NAME}"
-  - ls -alh "${GIT_INSTALLER_VOLUME}"
-  - sudo installer -verboseR -dumplog -pkg "${GIT_INSTALLER_PATH}" -target /
-  - sudo hdiutil detach "${GIT_INSTALLER_VOLUME}"
-  - export PYTHON_VERSION_LONG_SUGGESTIONS=$(git ls-remote --sort -v:refname --tags git://github.com/python/cpython.git "${PYTHON_VERSION}*" "v${PYTHON_VERSION}*" | grep -v '\^{}$' | awk '{print$2}' | sed 's#^refs/tags/##;s#^v##' | grep -v '[abcepr]')
-  - export PYTHON_VERSION_LONG=$(find_last_macos_py $PYTHON_VERSION_LONG_SUGGESTIONS)
-  - export PYTHON_VERSION_SHORT=$(echo ${PYTHON_VERSION_LONG} | awk -F. '{print$1"."$2}')
-  - echo "Selected version vars are:"
-  - echo "PYTHON_VERSION=${PYTHON_VERSION}"
-  - echo "PYTHON_VERSION_SHORT=${PYTHON_VERSION_SHORT}"
-  - echo "PYTHON_VERSION_LONG=${PYTHON_VERSION_LONG}"
-  - export PYTHON_INSTALL_PATH="/Library/Frameworks/Python.framework/Versions/${PYTHON_VERSION_SHORT}"
-  - export PYTHON_INSTALL_EXE="${PYTHON_INSTALL_PATH}/bin/python${PYTHON_VERSION_SHORT}"
-  - export PATH="${PYTHON_INSTALL_PATH}/bin:${PATH}"
-  - export PYTHON_VENV_PATH="${HOME}/virtualenv/python${PYTHON_VERSION_SHORT}"
-  - export PYTHON_INSTALLER_PATH="${PYTHON_INSTALLER_DIR_PATH}/python-${PYTHON_VERSION_LONG}.pkg"
-  - echo "PYTHON_INSTALLER_PATH=${PYTHON_INSTALLER_PATH}"
-  - env
-  - >
-    stat "${PYTHON_INSTALLER_PATH}" &>/dev/null || wget -O "${PYTHON_INSTALLER_PATH}" "https://www.python.org/ftp/python/${PYTHON_VERSION_LONG}/python-${PYTHON_VERSION_LONG}-macosx10.6.pkg"
-  - stat "${PYTHON_INSTALLER_PATH}" >/dev/null
-  - sudo installer -verboseR -dumplog -pkg "${PYTHON_INSTALLER_PATH}" -target /
-  - ls "${PYTHON_INSTALL_PATH}/bin"
-  - ls -lh "${PYTHON_INSTALL_EXE}"
-  - stat "${PYTHON_INSTALL_EXE}"
-  - /Applications/Python\ ${PYTHON_VERSION_SHORT}/Install\ Certificates.command || echo "No need to fix certificates"
-  - curl https://bootstrap.pypa.io/get-pip.py | ${PYTHON_INSTALL_EXE}
-  - >
-    "${PYTHON_INSTALL_EXE}" -m pip install -U pip
-  - >
-    "${PYTHON_INSTALL_EXE}" -m pip install -U virtualenv
-  - >
-    "${PYTHON_INSTALL_EXE}" -m virtualenv "${PYTHON_VENV_PATH}"
-  - . "${PYTHON_VENV_PATH}/bin/activate"
-  - curl https://bootstrap.pypa.io/get-pip.py | python
-  - python --version
-  - pip --version
-  before_cache:
-  - brew --cache
 - &python_3_7_mixture
   python: &mainstream_python 3.7
-- &pure_python_base
-  <<: *stage_test
-  <<: *python_3_7_mixture
 - &pure_python_base_priority
-  <<: *pure_python_base
+  <<: *python_3_7_mixture
   <<: *stage_test_priority
 - &lint_python_base
   <<: *stage_lint
@@ -170,7 +42,7 @@ jobs:
   - env: TOXENV=pre-commit-failing
   - python: nightly
   include:
-  - python: *pypy2
+  - python: pypy
     env:
       PYTEST_ADDOPTS: >-
         '-p no:warnings'
@@ -202,42 +74,6 @@ jobs:
     # mainstream here (3.7)
   - <<: *pure_python_base_priority
     python: nightly
-  - <<: *osx_python_base
-    <<: *manual_run_or_cron
-    python: 2.7
-    env:
-      PYTHON_VERSION: 2.7
-  - <<: *osx_python_base
-    <<: *manual_run_or_cron
-    python: 3.5
-    env:
-      PYTHON_VERSION: 3.5
-  - <<: *osx_python_base
-    python: 3.6
-    env:
-      PYTHON_VERSION: 3.6
-  - <<: *osx_python_base
-    python: *mainstream_python
-    env:
-      PYTHON_VERSION: *mainstream_python
-  - <<: *osx_python_base
-    <<: *manual_run_or_cron
-    before_install: *install-from-pyenv
-    python: nightly
-    env:
-    - PYTHON_VERSION=3.8-dev
-    - *env_pyenv
-    - *env_path
-  - <<: *osx_python_base
-    <<: *manual_run_or_cron
-    osx_image: xcode9.4
-    before_install: *install-from-pyenv
-    python: pypy3.6-7.1.0
-    env:
-    - PYTHON_VERSION=pypy3.6-7.1.0
-    - *env_pyenv
-    - *env_path
-  # pypy2.7-5.10.0 fails under OS X because it's unsupported
   - <<: *stage_deploy
     if: tag IS present
     <<: *python_3_7_mixture
@@ -253,13 +89,13 @@ cache:
   - $HOME/.cache/pre-commit
   - $HOME/.pre-commit
   - $HOME/virtualenv/python$(python -c 'import platform; print(platform.python_version())')
-  - $HOME/Library/Caches/Homebrew
 
 install:
 - python -m pip install --upgrade virtualenv
 - python -m pip install tox
 - python -m tox --notest  # Pre-populate a virtualenv with dependencies
-- *python_ssl_openssl_version
+- >-
+  python -c 'import ssl; print("\nOPENSSL_VERSION: " + ssl.OPENSSL_VERSION + "\nOPENSSL_VERSION_INFO: " + repr(ssl.OPENSSL_VERSION_INFO) + "\nOPENSSL_VERSION_NUMBER: " + repr(ssl.OPENSSL_VERSION_NUMBER))'
 - >-
   ".tox/${TOXENV:-python}/bin/python" -m OpenSSL.debug || true
 
@@ -284,7 +120,4 @@ after_failure:
 stages:
 - *stage_lint_name
 - *stage_test_priority_name
-- *stage_test_name
-- name: *stage_test_osx_name
-  if: type IN (api, cron) OR tag IS present
 - name: *stage_deploy_name


### PR DESCRIPTION
This change gets rid of macOS jobs in Travis CI because they are
already present in GitHub Actions CI/CD workflows.

❓ **What kind of change does this PR introduce?**
  - [ ] 🐞 bug fix
  - [ ] 🐣 feature
  - [ ] 📋 docs update
  - [x] 📋 tests/coverage improvement
  - [x] 📋 refactoring
  - [ ] 💥 other

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cherrypy/cheroot/336)
<!-- Reviewable:end -->
