### PR TITLE
Remove testmon as its dependencies are incompatible.

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -3,10 +3,6 @@ addopts =
     # `pytest-xdist`:
     --numprocesses=auto
 
-    # `pytest-mon`:
-    # useful for live testing with `pytest-watch` during development:
-    --testmon
-
     # show 10 slowest invocations:
     --durations=10
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -91,7 +91,6 @@ testing =
     pytest-forked>=1.2.0; sys_platform != "win32" and (python_version < '3.0' or python_version > '3.4')
     pytest-mock>=1.11.0
     pytest-sugar>=0.9.3
-    pytest-testmon<1.0.0
     pytest-watch==4.2.0
     pytest-xdist>=1.28.0
 

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,7 @@ deps =
     pip>=19.1
     wheel
 commands =
-    pytest --testmon-off {posargs}
+    pytest {posargs}
     codecov -f coverage.xml -X gcov
 usedevelop = True
 extras = testing


### PR DESCRIPTION
❓ **What kind of change does this PR introduce?**
  - [x] 🐞 bug fix
  - [ ] 🐣 feature
  - [ ] 📋 docs update
  - [ ] 📋 tests/coverage improvement
  - [ ] 📋 refactoring
  - [ ] 💥 other

📋 **What is the related issue number (starting with `#`)**

#335

❓ **What is the current behavior?** (You can also link to an open issue here)

With 2020-resolver enabled in pip, attempting to install dev dependencies results in enough conflicts that the resolver never completes.

❓ **What is the new behavior (if this is a feature change)?**

Dependencies no longer conflict and the test suite can run. Probably docs builds will run also.

This functionality can be added back once `testmon > 1` can be supported.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cherrypy/cheroot/338)
<!-- Reviewable:end -->
