### PR TITLE
server: raise exceptions from worker threads on serve() thread

### DIFF
--- a/cheroot/test/test_server.py
+++ b/cheroot/test/test_server.py
@@ -119,6 +119,7 @@ def test_stop_interrupts_serve():
 
 def test_server_interrupt():
     """Check that assigning interrupt stops the server."""
+    interrupt_msg = 'should catch {uuid!s}'.format(uuid=uuid.uuid4())
     raise_marker_sentinel = object()
 
     httpserver = HTTPServer(
@@ -133,7 +134,7 @@ def test_server_interrupt():
         try:
             httpserver.serve()
         except RuntimeError as e:
-            if str(e) == 'should catch':
+            if str(e) == interrupt_msg:
                 result_q.put(raise_marker_sentinel)
 
     httpserver.prepare()
@@ -145,7 +146,7 @@ def test_server_interrupt():
 
     # this exception is raised on the serve() thread,
     # not in the calling context.
-    httpserver.interrupt = RuntimeError('should catch')
+    httpserver.interrupt = RuntimeError(interrupt_msg)
 
     serve_thread.join(0.5)
     assert not serve_thread.is_alive()

--- a/cheroot/test/test_server.py
+++ b/cheroot/test/test_server.py
@@ -119,6 +119,8 @@ def test_stop_interrupts_serve():
 
 def test_server_interrupt():
     """Check that assigning interrupt stops the server."""
+    raise_marker_sentinel = object()
+
     httpserver = HTTPServer(
         bind_addr=(ANY_INTERFACE_IPV4, EPHEMERAL_PORT),
         gateway=Gateway,
@@ -132,7 +134,7 @@ def test_server_interrupt():
             httpserver.serve()
         except RuntimeError as e:
             if str(e) == 'should catch':
-                result_q.put('caught it')
+                result_q.put(raise_marker_sentinel)
 
     httpserver.prepare()
     serve_thread = threading.Thread(target=serve_thread)
@@ -147,7 +149,7 @@ def test_server_interrupt():
 
     serve_thread.join(0.5)
     assert not serve_thread.is_alive()
-    assert result_q.get_nowait() == 'caught it'
+    assert result_q.get_nowait() is raise_marker_sentinel
 
 
 def test_serving_is_false_and_stop_returns_after_ctrlc():


### PR DESCRIPTION
❓ **What kind of change does this PR introduce?**
  - [x] 🐞 bug fix
  - [ ] 🐣 feature
  - [ ] 📋 docs update
  - [ ] 📋 tests/coverage improvement
  - [x] 📋 refactoring
  - [ ] 💥 other

📋 **What is the related issue number (starting with `#`)**

https://github.com/cherrypy/cherrypy/issues/1873

❓ **What is the current behavior?** (You can also link to an open issue here)

Exceptions from worker threads are raised in the context that `stop()` is called, rather than the thread that `serve()` runs on - this breaks a test in cherrypy.

❓ **What is the new behavior (if this is a feature change)?**

This was inadvertently changed in https://github.com/cherrypy/cheroot/pull/309 - this reverts the behavior to raise the exception from the `serve()` thread as it was previously.

📋 **Other information**:



📋 **Checklist**:

  - [x] I think the code is well written
  - [x] I wrote [good commit messages][1]
  - [x] I have [squashed related commits together][2] after the changes have been approved
  - [x] Unit tests for the changes exist
  - [ ] Integration tests for the changes exist (if applicable)
  - [x] I used the same coding conventions as the rest of the project
  - [x] The new code doesn't generate linter offenses
  - [ ] Documentation reflects the changes
  - [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences

[1]: http://chris.beams.io/posts/git-commit/
[2]: https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cherrypy/cheroot/340)
<!-- Reviewable:end -->
