### PR TITLE
🐛 Suppress legit OS errors on socket shutdown

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,9 @@
   waiting for a ``tick`` event, addressing performance
   degradation introduced in v8.1.0.
 
+- :issue:`341` via :pr:`342`: Suppress legitimate OS errors
+  expected on shutdown.
+
 .. scm-version-title:: v8.4.8
 
 - :issue:`317` via :pr:`337`: Fixed a regression in

--- a/cheroot/errors.py
+++ b/cheroot/errors.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """Collection of exceptions raised and/or processed by Cheroot."""
 
 from __future__ import absolute_import, division, print_function
@@ -56,3 +57,24 @@ socket_errors_nonblocking = plat_specific_errors(
 if sys.platform == 'darwin':
     socket_errors_to_ignore.extend(plat_specific_errors('EPROTOTYPE'))
     socket_errors_nonblocking.extend(plat_specific_errors('EPROTOTYPE'))
+
+
+acceptable_sock_shutdown_error_codes = {
+    errno.ENOTCONN,
+    errno.EPIPE, errno.ESHUTDOWN,  # corresponds to BrokenPipeError in Python 3
+    errno.ECONNRESET,  # corresponds to ConnectionResetError in Python 3
+}
+"""Errors that may happen during the connection close sequence.
+
+* ENOTCONN — client is no longer connected
+* EPIPE — write on a pipe while the other end has been closed
+* ESHUTDOWN — write on a socket which has been shutdown for writing
+* ECONNRESET — connection is reset by the peer
+
+Ref: https://github.com/cherrypy/cheroot/issues/341#issuecomment-735884889
+"""
+
+try:  # py3
+    acceptable_sock_shutdown_exceptions = (BrokenPipeError, ConnectionResetError)
+except NameError:  # py2
+    acceptable_sock_shutdown_exceptions = ()

--- a/cheroot/server.py
+++ b/cheroot/server.py
@@ -75,7 +75,6 @@ import logging
 import platform
 import contextlib
 import threading
-import errno
 
 try:
     from functools import lru_cache
@@ -1478,9 +1477,10 @@ class HTTPConnection:
 
         try:
             shutdown(socket.SHUT_RDWR)  # actually send a TCP FIN
+        except errors.acceptable_sock_shutdown_exceptions:
+            pass
         except socket.error as e:
-            # Suppress "client is no longer connected"
-            if e.errno != errno.ENOTCONN:
+            if e.errno not in errors.acceptable_sock_shutdown_error_codes:
                 raise
 
 


### PR DESCRIPTION
When closing a socket we normally want to terminate the transport-
level connection by sending a TCP FIN packet over the wire. This works
great if the client is willing to perform a 3-way handshake but
sometimes the client-side just drops the connection by sending an RST
instead of a FIN. In this case, our server-side `socket.shutdown()`
call will raise an OSError (socket.error on Python 2) or its
derivatives. Which is perfectly fine and it's alright for us to ignore
those.

The kernel socket close helper rewrite introduced a behavior of only
suppressing ENOTCONN in v8.4.8 (the case when the client is no longer
with us) but it left own a few other cases that may be happening too.

This change fixes that by extending the list of errors that are to be
suppressed. Here's what's handled from now on:
  * ENOTCONN — client is no longer connected
  * EPIPE — write on a pipe while the other end has been closed
  * ESHUTDOWN — write on a socket which has been shutdown for writing
  * ECONNRESET — connection is reset by the peer

❓ **What kind of change does this PR introduce?**
  - [x] 🐞 bug fix
  - [ ] 🐣 feature
  - [ ] 📋 docs update
  - [ ] 📋 tests/coverage improvement
  - [ ] 📋 refactoring
  - [ ] 💥 other

📋 **What is the related issue number (starting with `#`)**

Fixes #341

❓ **What is the current behavior?** (You can also link to an open issue here)

Connection drop/reset/shutdown initiated by the client-side while the server attempts to send a TCP FIN triggers an unhandled OSError/socket.error during the socket shutdown and thus leaks into the logs.

❓ **What is the new behavior (if this is a feature change)?**

It's handled gracefully and suppressed.

📋 **Other information**:

Refs:
  * https://en.wikipedia.org/wiki/Transmission_Control_Protocol#Connection_termination
  * http://cs.baylor.edu/~donahoo/practical/CSockets/TCPRST.pdf
  * https://github.com/cherrypy/cheroot/issues/341#issuecomment-735884889

📋 **Checklist**:

  - [x] I think the code is well written
  - [x] I wrote [good commit messages][1]
  - [x] I have [squashed related commits together][2] after the changes have been approved
  - [ ] Unit tests for the changes exist
  - [ ] Integration tests for the changes exist (if applicable)
  - [x] I used the same coding conventions as the rest of the project
  - [x] The new code doesn't generate linter offenses
  - [ ] Documentation reflects the changes
  - [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences

[1]: http://chris.beams.io/posts/git-commit/
[2]: https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cherrypy/cheroot/342)
<!-- Reviewable:end -->
