### PR TITLE
Avoid ssl alert bad certificate error from ssl clients

### DIFF
--- a/cheroot/ssl/builtin.py
+++ b/cheroot/ssl/builtin.py
@@ -301,6 +301,7 @@ class BuiltinSSLAdapter(Adapter):
                     'certificate verify failed',  # client cert w/o trusted CA
                     'version too low',  # caused by SSL3 connections
                     'unsupported protocol',  # caused by TLS1 connections
+                    'sslv3 alert bad certificate'
                 )
                 if _assert_ssl_exc_contains(ex, *_block_errors):
                     # Accepted error, let's pass


### PR DESCRIPTION
This commit is to avoid the alert bad certificate error that keeps happening when some requests.

Signed-off-by: Nizamudeen A <nia@redhat.com>

❓ **What kind of change does this PR introduce?**
  - [x] 🐞 bug fix
  - [ ] 🐣 feature
  - [ ] 📋 docs update
  - [ ] 📋 tests/coverage improvement
  - [ ] 📋 refactoring
  - [ ] 💥 other

📋 **What is the related issue number (starting with `#`)**

#347

❓ **What is the current behavior?** (You can also link to an open issue here)



❓ **What is the new behavior (if this is a feature change)?**



📋 **Other information**:



📋 **Checklist**:

  - [ ] I think the code is well written
  - [ ] I wrote [good commit messages][1]
  - [ ] I have [squashed related commits together][2] after the changes have been approved
  - [ ] Unit tests for the changes exist
  - [ ] Integration tests for the changes exist (if applicable)
  - [ ] I used the same coding conventions as the rest of the project
  - [ ] The new code doesn't generate linter offenses
  - [ ] Documentation reflects the changes
  - [ ] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences

[1]: http://chris.beams.io/posts/git-commit/
[2]: https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cherrypy/cheroot/348)
<!-- Reviewable:end -->
