### PR TITLE
server: fix ctrlc behavior & test

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,12 @@
   :py:meth:`HTTPServer.interrupt <cheroot.server.\
   HTTPServer.interrupt>` property -- by :user:`liamstask`.
 
+- :pr:`350`: Fixed the incarnation of an earlier regression
+  of not resetting the serving state
+  on :py:data:``SIGINT`` originally fixed by :pr:`322` and
+  :pr:`331` but reintroduced by the changes in :pr:`311`
+  -- by :user:`liamstask`.
+
 .. scm-version-title:: v8.5.0
 
 - :issue:`305` via :pr:`311`: In

--- a/cheroot/connections.py
+++ b/cheroot/connections.py
@@ -199,8 +199,6 @@ class ConnectionManager:
         self._serving = True
         try:
             self._run(expiration_interval)
-        except Exception:
-            raise
         finally:
             self._serving = False
 

--- a/cheroot/connections.py
+++ b/cheroot/connections.py
@@ -197,6 +197,14 @@ class ConnectionManager:
         Can be shut down by calling `stop()`.
         """
         self._serving = True
+        try:
+            self._run(expiration_interval)
+        except Exception:
+            raise
+        finally:
+            self._serving = False
+
+    def _run(self, expiration_interval):
         last_expiration_check = time.time()
 
         while not self._stop_requested:
@@ -221,8 +229,6 @@ class ConnectionManager:
             if (now - last_expiration_check) > expiration_interval:
                 self._expire()
                 last_expiration_check = now
-
-        self._serving = False
 
     def _remove_invalid_sockets(self):
         """Clean up the resources of any broken connections.

--- a/cheroot/test/test_server.py
+++ b/cheroot/test/test_server.py
@@ -172,10 +172,10 @@ def test_serving_is_false_and_stop_returns_after_ctrlc():
     httpserver.prepare()
 
     # Simulate a Ctrl-C on the first call to `run`.
-    def raise_keyboard_interrupt(*args):
+    def raise_keyboard_interrupt(*args, **kwargs):
         raise KeyboardInterrupt()
 
-    httpserver._connections.run = raise_keyboard_interrupt
+    httpserver._connections._selector.select = raise_keyboard_interrupt
 
     serve_thread = threading.Thread(target=httpserver.serve)
     serve_thread.start()


### PR DESCRIPTION
❓ **What kind of change does this PR introduce?**
  - [x] 🐞 bug fix
  - [ ] 🐣 feature
  - [ ] 📋 docs update
  - [x] 📋 tests/coverage improvement
  - [ ] 📋 refactoring
  - [ ] 💥 other

📋 **What is the related issue number (starting with `#`)**

#322 - re-raised per https://github.com/cherrypy/cheroot/pull/322#issuecomment-743219937

❓ **What is the current behavior?** (You can also link to an open issue here)

https://github.com/cherrypy/cheroot/pull/311 changed the implementation such that `test_serving_is_false_and_stop_returns_after_ctrlc()` no longer exercised the inner `while` loop within `ConnectionManager.run()`.

Since that entire `run()` routine is patched out within that test, it did not cover the case in which exceptions occurred inside that while loop.

Adjust the test to raise an exception from within that loop, and add a wrapper around `run()` to ensure `self._serving` is cleared appropriately.

❓ **What is the new behavior (if this is a feature change)?**



📋 **Other information**:



📋 **Checklist**:

  - [x] I think the code is well written
  - [x] I wrote [good commit messages][1]
  - [x] I have [squashed related commits together][2] after the changes have been approved
  - [x] Unit tests for the changes exist
  - [ ] Integration tests for the changes exist (if applicable)
  - [x] I used the same coding conventions as the rest of the project
  - [x] The new code doesn't generate linter offenses
  - [x] Documentation reflects the changes
  - [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences

[1]: http://chris.beams.io/posts/git-commit/
[2]: https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cherrypy/cheroot/350)
<!-- Reviewable:end -->
