### PR TITLE
Address #358: Only process valid connections

### DIFF
--- a/cheroot/connections.py
+++ b/cheroot/connections.py
@@ -216,7 +216,8 @@ class ConnectionManager:
                 if conn is self.server:
                     # New connection
                     new_conn = self._from_server_socket(self.server.socket)
-                    self.server.process_conn(new_conn)
+                    if new_conn is not None:
+                        self.server.process_conn(new_conn)
                 else:
                     # unregister connection from the selector until the server
                     # has read from it and returned it via put()


### PR DESCRIPTION
The `_from_server_socket` routine may return a `None` which should not be sent to workers to process.

❓ **What kind of change does this PR introduce?**
  - [x] 🐞 bug fix
  - [ ] 🐣 feature
  - [ ] 📋 docs update
  - [ ] 📋 tests/coverage improvement
  - [ ] 📋 refactoring
  - [ ] 💥 other

📋 **What is the related issue number (starting with `#`)**

#358

❓ **What is the current behavior?** (You can also link to an open issue here)

#358 

❓ **What is the new behavior (if this is a feature change)?**



📋 **Other information**:



📋 **Checklist**:

  - [x] I think the code is well written
  - [x] I wrote [good commit messages][1]
  - [ ] I have [squashed related commits together][2] after the changes have been approved
  - [ ] Unit tests for the changes exist
  - [ ] Integration tests for the changes exist (if applicable)
  - [ ] I used the same coding conventions as the rest of the project
  - [ ] The new code doesn't generate linter offenses
  - [ ] Documentation reflects the changes
  - [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences

[1]: http://chris.beams.io/posts/git-commit/
[2]: https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cherrypy/cheroot/359)
<!-- Reviewable:end -->
