### PR TITLE
Qualys security scanner kills all cheroot worker threads, hangs server, eats all available file descriptors

### DIFF
--- a/cheroot/workers/threadpool.py
+++ b/cheroot/workers/threadpool.py
@@ -125,7 +125,7 @@ class WorkerThread(threading.Thread):
                 try:
                     keep_conn_open = conn.communicate()
                 except SSLError as ex:
-                    self.server.error_log(f'ignored extra SSLError: {repr(ex)}')
+                    self.server.error_log(f'ignored extra SSLError {repr(ex)}')
                 finally:
                     if keep_conn_open:
                         self.server.put_conn(conn)

--- a/cheroot/workers/threadpool.py
+++ b/cheroot/workers/threadpool.py
@@ -14,6 +14,7 @@ import threading
 import time
 import socket
 import warnings
+from ssl import SSLError
 
 from six.moves import queue
 
@@ -123,6 +124,8 @@ class WorkerThread(threading.Thread):
                 keep_conn_open = False
                 try:
                     keep_conn_open = conn.communicate()
+                except SSLError as ex:
+                    self.server.error_log(f'ignored extra SSLError: {repr(ex)}')
                 finally:
                     if keep_conn_open:
                         self.server.put_conn(conn)


### PR DESCRIPTION
❓ **What kind of change does this PR introduce?**
  - [X] 🐞 bug fix
  - [ ] 🐣 feature
  - [ ] 📋 docs update
  - [ ] 📋 tests/coverage improvement
  - [ ] 📋 refactoring
  - [ ] 💥 other

📋 **What is the related issue number (starting with `#`)**

N/A

❓ **What is the current behavior?** (You can also link to an open issue here)

This was originally discovered by scanning our cherrypy-based server with the Qualys vulnerability scanner.  We later discovered we could reproduce the issue by:

- logging into our server on firefox
- shutting down the server
- regenerating the server cert (self-signed)
- restarting the server
- clicking Refresh on firefox *without* accepting the new cert.

The result is this exception logged:
```python-traceback
03/Mar/2021 18:55:49.533 ENGINE socket.error 1
Traceback (most recent call last):
  File "/root/.pex/installed_wheels/e41a25c4dd3432ad8f36767b07aff8afbe8b9c6a/cheroot-8.5.3.dev2+g473c546a.d20210303-py2.py3-none-any.whl/cheroot/server.py", line 1288, in communicate
    req.parse_request()
  File "/root/.pex/installed_wheels/e41a25c4dd3432ad8f36767b07aff8afbe8b9c6a/cheroot-8.5.3.dev2+g473c546a.d20210303-py2.py3-none-any.whl/cheroot/server.py", line 706, in parse_request
    success = self.read_request_line()
  File "/root/.pex/installed_wheels/e41a25c4dd3432ad8f36767b07aff8afbe8b9c6a/cheroot-8.5.3.dev2+g473c546a.d20210303-py2.py3-none-any.whl/cheroot/server.py", line 747, in read_request_line
    request_line = self.rfile.readline()
  File "/root/.pex/installed_wheels/e41a25c4dd3432ad8f36767b07aff8afbe8b9c6a/cheroot-8.5.3.dev2+g473c546a.d20210303-py2.py3-none-any.whl/cheroot/server.py", line 304, in readline
    data = self.rfile.readline(256)
  File "/usr/lib64/python3.6/_pyio.py", line 511, in readline
    b = self.read(nreadahead())
  File "/usr/lib64/python3.6/_pyio.py", line 495, in nreadahead
    readahead = self.peek(1)
  File "/usr/lib64/python3.6/_pyio.py", line 1063, in peek
    return self._peek_unlocked(size)
  File "/usr/lib64/python3.6/_pyio.py", line 1070, in _peek_unlocked
    current = self.raw.read(to_read)
  File "/usr/lib64/python3.6/socket.py", line 586, in readinto
    return self._sock.recv_into(b)
  File "/usr/lib64/python3.6/ssl.py", line 971, in recv_into
    return self.read(nbytes, buffer)
  File "/usr/lib64/python3.6/ssl.py", line 833, in read
    return self._sslobj.read(len, buffer)
  File "/usr/lib64/python3.6/ssl.py", line 590, in read
    v = self._sslobj.read(len, buffer)
ssl.SSLError: [SSL: DECRYPTION_FAILED_OR_BAD_RECORD_MAC] decryption failed or bad record mac (_ssl.c:2334)
```

(Note that I am using a locally-built version of cheroot with added logging to diagnose the error, but the same issue occurs with stock `cheroot` 8.5.2.  Unfortunately, this does mean the line numbers might not match exactly.)

This exception is followed by the death of the worker thread executing this request.  Hitting refresh as many times as the number of worker threads causes the server to become unresponsive.  However, it will continue to receive and queue requests, until the queued requests consume all available file descriptors.  Here is what `dynpool` will log once all worker threads are dead:

```log
03/Mar/2021 19:17:23.011  Thread pool: [current=10/idle=10/queue=221]
03/Mar/2021 19:17:30.019  Thread pool: [current=10/idle=10/queue=222]
03/Mar/2021 19:17:36.027  Thread pool: [current=10/idle=10/queue=223]
03/Mar/2021 19:17:37.029  Thread pool: [current=10/idle=10/queue=224]
03/Mar/2021 19:17:41.034  Thread pool: [current=10/idle=10/queue=225]
...
```

Note that, although the worker threads are dead, `cheroot` and `dynpool` think they are still alive.  Calling `ThreadPool._clear_dead_threads()` would clear the dead threads and allow `dynpool` to recover, but `clear_dead_threads` is only called from `shrink()`, and `dynpool` won't call `shrink()` because the number of worker threads is within limits.

The above exception is being caught and handled properly in `conn.communicate()`, but the worker thread is being killed by a second `SSLError` exception:

```python-traceback
Traceback (most recent call last):
  File "/usr/lib64/python3.6/threading.py", line 916, in _bootstrap_inner
    self.run()
  File "/root/.pex/installed_wheels/e41a25c4dd3432ad8f36767b07aff8afbe8b9c6a/cheroot-8.5.3.dev2+g473c546a.d20210303-py2.py3-none-any.whl/cheroot/workers/threadpool.py", line 133, in run
    keep_conn_open = conn.communicate()
  File "/root/.pex/installed_wheels/e41a25c4dd3432ad8f36767b07aff8afbe8b9c6a/cheroot-8.5.3.dev2+g473c546a.d20210303-py2.py3-none-any.whl/cheroot/server.py", line 1324, in communicate
    self._conditional_error(req, '500 Internal Server Error')
  File "/root/.pex/installed_wheels/e41a25c4dd3432ad8f36767b07aff8afbe8b9c6a/cheroot-8.5.3.dev2+g473c546a.d20210303-py2.py3-none-any.whl/cheroot/server.py", line 1371, in _conditional_error
    req.simple_response(response)
  File "/root/.pex/installed_wheels/e41a25c4dd3432ad8f36767b07aff8afbe8b9c6a/cheroot-8.5.3.dev2+g473c546a.d20210303-py2.py3-none-any.whl/cheroot/server.py", line 1124, in simple_response
    self.conn.wfile.write(EMPTY.join(buf))
  File "/root/.pex/installed_wheels/e41a25c4dd3432ad8f36767b07aff8afbe8b9c6a/cheroot-8.5.3.dev2+g473c546a.d20210303-py2.py3-none-any.whl/cheroot/makefile.py", line 438, in write
    res = super().write(val, *args, **kwargs)
  File "/root/.pex/installed_wheels/e41a25c4dd3432ad8f36767b07aff8afbe8b9c6a/cheroot-8.5.3.dev2+g473c546a.d20210303-py2.py3-none-any.whl/cheroot/makefile.py", line 36, in write
    self._flush_unlocked()
  File "/root/.pex/installed_wheels/e41a25c4dd3432ad8f36767b07aff8afbe8b9c6a/cheroot-8.5.3.dev2+g473c546a.d20210303-py2.py3-none-any.whl/cheroot/makefile.py", line 45, in _flush_unlocked
    n = self.raw.write(bytes(self._write_buf))
  File "/usr/lib64/python3.6/socket.py", line 604, in write
    return self._sock.send(b)
  File "/usr/lib64/python3.6/ssl.py", line 903, in send
    return self._sslobj.write(data)
  File "/usr/lib64/python3.6/ssl.py", line 601, in write
    return self._sslobj.write(data)
ssl.SSLError: [SSL: UNKNOWN_STATE] unknown state (_ssl.c:2187)
```


❓ **What is the new behavior (if this is a feature change)?**

With the proposed change, the SSL exceptions will still be logged, but the worker thread will survive.


📋 **Other information**:

This is my first foray into cheroot, so it's possible this isn't the right way to fix this.  We can discuss, and I can retest with alternate fixes.

Both the server and the firefox browser used to trigger the problem are running on CentOS 7.  The server is using python 3.6.

📋 **Checklist**:

  - [X] I think the code is well written
  - [ ] I wrote [good commit messages][1]
  - [ ] I have [squashed related commits together][2] after the changes have been approved
  - [ ] Unit tests for the changes exist
  - [ ] Integration tests for the changes exist (if applicable)
  - [X] I used the same coding conventions as the rest of the project
  - [X] The new code doesn't generate linter offenses
  - [ ] Documentation reflects the changes
  - [X] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences

[1]: http://chris.beams.io/posts/git-commit/
[2]: https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cherrypy/cheroot/365)
<!-- Reviewable:end -->
