### PR TITLE
Require setuptools, cheroot/__init__.py imports pkg_resources

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -67,6 +67,7 @@ install_requires =
     six>=1.11.0
     more_itertools>=2.6
     jaraco.functools
+    setuptools
 
 [options.extras_require]
 docs =


### PR DESCRIPTION
❓ **What kind of change does this PR introduce?**
  - [x] 🐞 bug fix
  - [ ] 🐣 feature
  - [ ] 📋 docs update
  - [ ] 📋 tests/coverage improvement
  - [ ] 📋 refactoring
  - [ ] 💥 other

📋 **What is the related issue number (starting with `#`)**

#

❓ **What is the current behavior?** (You can also link to an open issue here)
pkg_resources needs setuptools as a runtime dependency. Since it wasn't specified so far, there was a possibility of `ModuleNotFoundError: No module named 'pkg_resources'` in case of setuptools not being present. There is a way how to install packages without setuptools or setuptools can be uninstalled after cheroot package was installed. My PR prevents this error.


❓ **What is the new behavior (if this is a feature change)?**



📋 **Other information**:



📋 **Checklist**:

  - [x] I think the code is well written
  - [x] I wrote [good commit messages][1]
  - [ ] I have [squashed related commits together][2] after the changes have been approved
  - [ ] Unit tests for the changes exist
  - [ ] Integration tests for the changes exist (if applicable)
  - [x] I used the same coding conventions as the rest of the project
  - [x] The new code doesn't generate linter offenses
  - [ ] Documentation reflects the changes
  - [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences

[1]: http://chris.beams.io/posts/git-commit/
[2]: https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cherrypy/cheroot/367)
<!-- Reviewable:end -->
