### PR TITLE
Rethink the high num file descriptors test

### DIFF
--- a/cheroot/test/test_server.py
+++ b/cheroot/test/test_server.py
@@ -411,15 +411,11 @@ def many_open_sockets(request, resource_limit):
         for i in range(resource_limit):
             sock = socket.socket()
             test_sockets.append(sock)
-            # NOTE: We used to interrupt the loop early but this doesn't seem
-            # NOTE: to work well in envs with indeterministic runtimes like
-            # NOTE: PyPy. It looks like sometimes it frees some file
-            # NOTE: descriptors in between running this fixture and the actual
-            # NOTE: test code so the early break has been removed to try
-            # NOTE: address that. The approach may need to be rethought if the
-            # NOTE: issue reoccurs. Another approach may be disabling the GC.
+            # If we reach a high enough number, we don't need to open more
+            if sock.fileno() >= resource_limit:
+                break
         # Check we opened enough descriptors to reach a high number
-        the_highest_fileno = max(sock.fileno() for sock in test_sockets)
+        the_highest_fileno = test_sockets[-1].fileno()
         assert the_highest_fileno >= resource_limit
         yield the_highest_fileno
     finally:

--- a/cheroot/test/test_server.py
+++ b/cheroot/test/test_server.py
@@ -16,6 +16,7 @@ import requests
 import requests_unixsocket
 import six
 
+from pypytools.gc.custom import DefaultGc
 from six.moves import queue, urllib
 
 from .._compat import bton, ntob
@@ -362,6 +363,13 @@ if not IS_WINDOWS:
 
 
 @pytest.fixture
+def _garbage_bin():
+    """Disable garbage collection when this fixture is in use."""
+    with DefaultGc().nogc():
+        yield
+
+
+@pytest.fixture
 def resource_limit(request):
     """Set the resource limit two times bigger then requested."""
     resource = pytest.importorskip(
@@ -388,8 +396,13 @@ def resource_limit(request):
 
 
 @pytest.fixture
-def many_open_sockets(resource_limit):
+def many_open_sockets(request, resource_limit):
     """Allocate a lot of file descriptors by opening dummy sockets."""
+    # NOTE: `@pytest.mark.usefixtures` doesn't work on fixtures which
+    # NOTE: forces us to invoke this one dynamically to avoid having an
+    # NOTE: unused argument.
+    request.getfixturevalue('_garbage_bin')
+
     # Hoard a lot of file descriptors by opening and storing a lot of sockets
     test_sockets = []
     # Open a lot of file descriptors, so the next one the server

--- a/setup.cfg
+++ b/setup.cfg
@@ -140,6 +140,11 @@ testing =
     # here so that it's use is adjusted across Python 2 and Python 3:
     chardet
 
+    # The pypytools library provides a cross-implementation context
+    # manager for disabling garbage collection in specific blocks
+    # of the control flow:
+    pypytools
+
 [options.entry_points]
 console_scripts =
     cheroot = cheroot.cli:main


### PR DESCRIPTION
❓ **What kind of change does this PR introduce?**
  - [ ] 🐞 bug fix
  - [ ] 🐣 feature
  - [ ] 📋 docs update
  - [x] 📋 tests/coverage improvement
  - [x] 📋 refactoring
  - [ ] 💥 other

📋 **What is the related issue number (starting with `#`)**

#

❓ **What is the current behavior?** (You can also link to an open issue here)

Tests attempt to check if a socket created manually post-request has a high fileno.

❓ **What is the new behavior (if this is a feature change)?**

Instead of creating the test socket fd in test after the connection
has been processed, this patch attempts to spy on all the incoming
connections and record their file descriptors. This way, we'll know
for sure if there was a high-number fd returned via selectors.

This change also introduces disabling the GC for the duration of this test in hopes to make it stable under PyPy (knowing that GC is less deterministic there).

📋 **Other information**:

N/A

📋 **Checklist**:

  - [x] I think the code is well written
  - [x] I wrote [good commit messages][1]
  - [x] I have [squashed related commits together][2] after the changes have been approved
  - [ ] Unit tests for the changes exist
  - [x] Integration tests for the changes exist (if applicable)
  - [x] I used the same coding conventions as the rest of the project
  - [x] The new code doesn't generate linter offenses
  - [ ] Documentation reflects the changes
  - [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences

[1]: http://chris.beams.io/posts/git-commit/
[2]: https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cherrypy/cheroot/377)
<!-- Reviewable:end -->
