### PR TITLE
Use importlib.metadata instead of deprecated pkg_resources

### DIFF
--- a/cheroot/__init__.py
+++ b/cheroot/__init__.py
@@ -4,12 +4,15 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 try:
-    import pkg_resources
+    from importlib.metadata import version
 except ImportError:
-    pass
+    try:
+        from importlib_metadata import version
+    except ImportError:
+        pass
 
 
 try:
-    __version__ = pkg_resources.get_distribution('cheroot').version
+    __version__ = version('cheroot')
 except Exception:
     __version__ = 'unknown'

--- a/cheroot/__init__.py
+++ b/cheroot/__init__.py
@@ -4,15 +4,12 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 try:
-    from importlib.metadata import version
+    from importlib import metadata
 except ImportError:
-    try:
-        from importlib_metadata import version
-    except ImportError:
-        pass
+    import importlib_metadata as metadata  # noqa: WPS440
 
 
 try:
-    __version__ = version('cheroot')
+    __version__ = metadata.version('cheroot')
 except Exception:
     __version__ = 'unknown'

--- a/setup.cfg
+++ b/setup.cfg
@@ -64,6 +64,7 @@ setup_requires =
 install_requires =
   backports.functools_lru_cache; python_version < '3.3'
   selectors2; python_version< '3.4'
+  importlib_metadata; python_version < '3.8'
   six>=1.11.0
   # NOTE: `more-itertools` has a bug in their package metadata. They
   # NOTE: have dropped the testing of Python 3.5 from their CI but


### PR DESCRIPTION
pkg_resources is deprecated upstream and does not handle modern .dist-info directories correctly. Specifically it does not honor the [new replacement rules](https://packaging.python.org/en/latest/specifications/binary-distribution-format/#escaping-and-unicode). As a result, it can't find some of cheroot's dependencies on modern Gentoo systems and ultimately [fails to load](https://bugs.gentoo.org/834522) with a DistributionNotFound error.

pkg_resources is only used to get the cheroot version and can easily be replaced with [importlib.metadata](https://docs.python.org/3/library/importlib.metadata.html), the intended replacement for this specific use-case. For python versions before 3.8, attempt to use the importlib_metadata backport instead.


❓ **What kind of change does this PR introduce?**

* [x] 🐞 bug fix
* [ ] 🐣 feature
* [ ] 📋 docs update
* [ ] 📋 tests/coverage improvement
* [ ] 📋 refactoring
* [ ] 💥 other

📋 **Contribution checklist:**

I do not know how to add tests for this specific failure case, so I omitted them.

* [x] I wrote descriptive pull request text above
* [x] I think the code is well written
* [x] I wrote [good commit messages]
* [ ] I have [squashed related commits together][related squash] after
      the changes have been approved
* [ ] Unit tests for the changes exist
* [ ] Integration tests for the changes exist (if applicable)
* [x] I used the same coding conventions as the rest of the project
* [x] The new code doesn't generate linter offenses
* [ ] Documentation reflects the changes
* [x] The PR relates to *only* one subject with a clear title
      and description in grammatically correct, complete sentences

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cherrypy/cheroot/500)
<!-- Reviewable:end -->
