### PR TITLE
Set worker thread names as str

### DIFF
--- a/cheroot/workers/threadpool.py
+++ b/cheroot/workers/threadpool.py
@@ -178,7 +178,7 @@ class ThreadPool:
         for worker in self._threads:
             worker.name = (
                 'CP Server {worker_name!s}'.
-                format(worker_name=worker.name),
+                format(worker_name=worker.name)
             )
             worker.start()
         for worker in self._threads:
@@ -228,7 +228,7 @@ class ThreadPool:
         worker = WorkerThread(self.server)
         worker.name = (
             'CP Server {worker_name!s}'.
-            format(worker_name=worker.name),
+            format(worker_name=worker.name)
         )
         worker.start()
         return worker


### PR DESCRIPTION
❓ **What kind of change does this PR introduce?**

* [X] 🐞 bug fix
* [ ] 🐣 feature
* [ ] 📋 docs update
* [ ] 📋 tests/coverage improvement
* [ ] 📋 refactoring
* [ ] 💥 other

📋 **What is the related issue number (starting with `#`)**

None

❓ **What is the current behavior?** (You can also link to an open issue here)
Since the refactoring 7af66b0 the Cheroot worker threads are named like "('CP Server Thread-9',)".


❓ **What is the new behavior (if this is a feature change)?**
The worker threads are again correctly named "CP Server Thread-$i".


📋 **Other information**:
A leftover comma transformed the string to a tuple.


📋 **Contribution checklist:**

(If you're a first-timer, check out
[this guide on making great pull requests][making a lovely PR])

* [x] I wrote descriptive pull request text above
* [x] I think the code is well written
* [x] I wrote [good commit messages]
* [x] I have [squashed related commits together][related squash] after
      the changes have been approved
* [ ] Unit tests for the changes exist
* [ ] Integration tests for the changes exist (if applicable)
* [x] I used the same coding conventions as the rest of the project
* [x] The new code doesn't generate linter offenses
* [ ] Documentation reflects the changes
* [x] The PR relates to *only* one subject with a clear title
      and description in grammatically correct, complete sentences

[good commit messages]: http://chris.beams.io/posts/git-commit/
[making a lovely PR]: https://mtlynch.io/code-review-love/
[related squash]:
https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cherrypy/cheroot/503)
<!-- Reviewable:end -->
