### PR TITLE
__init__: generate correct version number

### DIFF
--- a/cheroot/__init__.py
+++ b/cheroot/__init__.py
@@ -1,6 +1,7 @@
 """High-performance, pure-Python HTTP server used by CherryPy."""
 
 from __future__ import absolute_import, division, print_function
+import re
 __metaclass__ = type
 
 try:
@@ -10,6 +11,9 @@ except ImportError:
 
 
 try:
-    __version__ = pkg_resources.get_distribution('cheroot').version
+    __version__ = re.search(
+        r'(?x)^(\d+)\.(\d+)(\.(\d+))?([ab](\d+))?',
+        pkg_resources.get_distribution('cheroot').version,
+    ).expand(r'\1.\2\3\5')
 except Exception:
     __version__ = 'unknown'


### PR DESCRIPTION
Closes #506

The distribution package number is reused as Python package version.

This leads to errors in distutils.version.StrictVersion like

    ValueError: invalid version number '8.6.0+ds1'

Use a regular expression to extract a valid version number.

Signed-off-by: Heinrich Schuchardt <heinrich.schuchardt@canonical.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cherrypy/cheroot/507)
<!-- Reviewable:end -->
