### PR TITLE
Bump transitive deps in pip-tools-managed lockfiles for urllib3

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -68,6 +68,12 @@ filterwarnings =
   # Ref: https://github.com/certifi/python-certifi/issues/183
   ignore:path is deprecated. Use files.. instead. Refer to https.//importlib-resources.readthedocs.io/en/latest/using.html#migrating-from-legacy for migration advice.:DeprecationWarning:certifi.core
 
+  # FIXME: drop once requests-toolbelt stops importing `urllib3.contrib.pyopenssl`
+  # Refs:
+  # * https://github.com/requests/toolbelt/issues/331
+  # * https://github.com/urllib3/urllib3/issues/2680
+  ignore:'urllib3.contrib.pyopenssl' module is deprecated and will be removed in a future release of urllib3 2.x. Read more in this issue. https.//github.com/urllib3/urllib3/issues/2680:DeprecationWarning:requests_toolbelt._compat
+
 junit_duration_report = call
 junit_family = xunit2
 junit_suite_name = cheroot_test_suite

--- a/requirements/tox-py27-cp27-darwin-x86_64.txt
+++ b/requirements/tox-py27-cp27-darwin-x86_64.txt
@@ -184,7 +184,7 @@ typing==3.10.0.0
     # via
     #   importlib-resources
     #   pathlib2
-urllib3==1.26.8 ; python_version != "3.4"
+urllib3==1.26.12 ; python_version != "3.4"
     # via
     #   -r requirements/tox-py27-cp27-darwin-x86_64.in
     #   requests

--- a/requirements/tox-py27-cp27-linux-x86_64.txt
+++ b/requirements/tox-py27-cp27-linux-x86_64.txt
@@ -184,7 +184,7 @@ typing==3.10.0.0
     # via
     #   importlib-resources
     #   pathlib2
-urllib3==1.26.8 ; python_version != "3.4"
+urllib3==1.26.12 ; python_version != "3.4"
     # via
     #   -r requirements/tox-py27-cp27-linux-x86_64.in
     #   requests

--- a/requirements/tox-py27-cp27-win32-amd64.txt
+++ b/requirements/tox-py27-cp27-win32-amd64.txt
@@ -184,7 +184,7 @@ typing==3.10.0.0
     # via
     #   importlib-resources
     #   pathlib2
-urllib3==1.26.8 ; python_version != "3.4"
+urllib3==1.26.12 ; python_version != "3.4"
     # via
     #   -r requirements/tox-py27-cp27-win32-amd64.in
     #   requests

--- a/requirements/tox-py310-cp310-darwin-x86_64.txt
+++ b/requirements/tox-py310-cp310-darwin-x86_64.txt
@@ -127,7 +127,7 @@ trustme==0.9.0
     # via -r requirements/tox-py310-cp310-darwin-x86_64.in
 typing-extensions==4.3.0
     # via pydantic
-urllib3==1.26.8 ; python_version != "3.4"
+urllib3==1.26.12 ; python_version != "3.4"
     # via
     #   -r requirements/tox-py310-cp310-darwin-x86_64.in
     #   requests

--- a/requirements/tox-py310-cp310-linux-x86_64.txt
+++ b/requirements/tox-py310-cp310-linux-x86_64.txt
@@ -127,7 +127,7 @@ trustme==0.9.0
     # via -r requirements/tox-py310-cp310-linux-x86_64.in
 typing-extensions==4.3.0
     # via pydantic
-urllib3==1.26.8 ; python_version != "3.4"
+urllib3==1.26.12 ; python_version != "3.4"
     # via
     #   -r requirements/tox-py310-cp310-linux-x86_64.in
     #   requests

--- a/requirements/tox-py310-cp310-win32-amd64.txt
+++ b/requirements/tox-py310-cp310-win32-amd64.txt
@@ -129,7 +129,7 @@ trustme==0.9.0
     # via -r requirements/tox-py310-cp310-win32-amd64.in
 typing-extensions==4.3.0
     # via pydantic
-urllib3==1.26.8 ; python_version != "3.4"
+urllib3==1.26.12 ; python_version != "3.4"
     # via
     #   -r requirements/tox-py310-cp310-win32-amd64.in
     #   requests

--- a/requirements/tox-py311-cp311-darwin-x86_64.txt
+++ b/requirements/tox-py311-cp311-darwin-x86_64.txt
@@ -127,7 +127,7 @@ trustme==0.9.0
     # via -r requirements/tox-py311-cp311-darwin-x86_64.in
 typing-extensions==4.3.0
     # via pydantic
-urllib3==1.26.8 ; python_version != "3.4"
+urllib3==1.26.12 ; python_version != "3.4"
     # via
     #   -r requirements/tox-py311-cp311-darwin-x86_64.in
     #   requests

--- a/requirements/tox-py311-cp311-linux-x86_64.txt
+++ b/requirements/tox-py311-cp311-linux-x86_64.txt
@@ -127,7 +127,7 @@ trustme==0.9.0
     # via -r requirements/tox-py311-cp311-linux-x86_64.in
 typing-extensions==4.3.0
     # via pydantic
-urllib3==1.26.8 ; python_version != "3.4"
+urllib3==1.26.12 ; python_version != "3.4"
     # via
     #   -r requirements/tox-py311-cp311-linux-x86_64.in
     #   requests

--- a/requirements/tox-py311-cp311-win32-amd64.txt
+++ b/requirements/tox-py311-cp311-win32-amd64.txt
@@ -129,7 +129,7 @@ trustme==0.9.0
     # via -r requirements/tox-py311-cp311-win32-amd64.in
 typing-extensions==4.3.0
     # via pydantic
-urllib3==1.26.8 ; python_version != "3.4"
+urllib3==1.26.12 ; python_version != "3.4"
     # via
     #   -r requirements/tox-py311-cp311-win32-amd64.in
     #   requests

--- a/requirements/tox-py34-cp34-linux-x86_64.txt
+++ b/requirements/tox-py34-cp34-linux-x86_64.txt
@@ -17,11 +17,10 @@ docopt==0.6.2             # via pytest-watch
 execnet==1.7.1            # via pytest-xdist
 idna==2.8                 # via requests, trustme
 importlib-metadata==1.1.3  # via pluggy, pytest
-importlib-resources==1.0.2  # via jaraco-text, jaraco.text
-jaraco-text==3.2.0
+importlib-resources==1.0.2  # via jaraco.text
 jaraco.apt==2.0           # via jaraco.context
 jaraco.context==2.0
-jaraco.functools==2.0     # via jaraco-text, jaraco.text, tempora, yg.lockfile
+jaraco.functools==2.0     # via jaraco.text, tempora, yg.lockfile
 jaraco.text==3.2.0
 more-itertools==7.2.0     # via jaraco.functools, pytest
 packaging==20.9           # via pytest, pytest-sugar
@@ -47,7 +46,7 @@ requests-toolbelt==0.9.1
 requests-unixsocket==0.3.0
 requests==2.21.0          # via requests-toolbelt, requests-unixsocket
 scandir==1.10.0           # via pathlib2
-six==1.16.0               # via cryptography, jaraco-text, jaraco.apt, jaraco.text, pathlib2, pyopenssl, pytest, pytest-xdist, tempora
+six==1.16.0               # via cryptography, jaraco.apt, jaraco.text, pathlib2, pyopenssl, pytest, pytest-xdist, tempora
 tempora==1.14.1           # via portend, yg.lockfile
 termcolor==1.1.0          # via pytest-sugar
 trustme==0.9.0

--- a/requirements/tox-py35-cp35-darwin-x86_64.txt
+++ b/requirements/tox-py35-cp35-darwin-x86_64.txt
@@ -139,7 +139,7 @@ toml==0.10.2
     #   pytest
 trustme==0.9.0
     # via -r requirements/tox-py35-cp35-darwin-x86_64.in
-urllib3==1.26.8 ; python_version != "3.4"
+urllib3==1.26.9 ; python_version != "3.4"
     # via
     #   -r requirements/tox-py35-cp35-darwin-x86_64.in
     #   requests

--- a/requirements/tox-py35-cp35-linux-x86_64.txt
+++ b/requirements/tox-py35-cp35-linux-x86_64.txt
@@ -139,7 +139,7 @@ toml==0.10.2
     #   pytest
 trustme==0.9.0
     # via -r requirements/tox-py35-cp35-linux-x86_64.in
-urllib3==1.26.8 ; python_version != "3.4"
+urllib3==1.26.9 ; python_version != "3.4"
     # via
     #   -r requirements/tox-py35-cp35-linux-x86_64.in
     #   requests

--- a/requirements/tox-py35-cp35-win32-amd64.txt
+++ b/requirements/tox-py35-cp35-win32-amd64.txt
@@ -141,7 +141,7 @@ toml==0.10.2
     #   pytest
 trustme==0.9.0
     # via -r requirements/tox-py35-cp35-win32-amd64.in
-urllib3==1.26.8 ; python_version != "3.4"
+urllib3==1.26.9 ; python_version != "3.4"
     # via
     #   -r requirements/tox-py35-cp35-win32-amd64.in
     #   requests

--- a/requirements/tox-py36-cp36-darwin-x86_64.txt
+++ b/requirements/tox-py36-cp36-darwin-x86_64.txt
@@ -127,7 +127,7 @@ trustme==0.9.0
     # via -r requirements/tox-py36-cp36-darwin-x86_64.in
 typing-extensions==4.1.0
     # via importlib-metadata
-urllib3==1.26.8 ; python_version != "3.4"
+urllib3==1.26.12 ; python_version != "3.4"
     # via
     #   -r requirements/tox-py36-cp36-darwin-x86_64.in
     #   requests

--- a/requirements/tox-py36-cp36-linux-x86_64.txt
+++ b/requirements/tox-py36-cp36-linux-x86_64.txt
@@ -127,7 +127,7 @@ trustme==0.9.0
     # via -r requirements/tox-py36-cp36-linux-x86_64.in
 typing-extensions==4.1.0
     # via importlib-metadata
-urllib3==1.26.8 ; python_version != "3.4"
+urllib3==1.26.12 ; python_version != "3.4"
     # via
     #   -r requirements/tox-py36-cp36-linux-x86_64.in
     #   requests

--- a/requirements/tox-py36-cp36-win32-amd64.txt
+++ b/requirements/tox-py36-cp36-win32-amd64.txt
@@ -129,7 +129,7 @@ trustme==0.9.0
     # via -r requirements/tox-py36-cp36-win32-amd64.in
 typing-extensions==4.1.0
     # via importlib-metadata
-urllib3==1.26.8 ; python_version != "3.4"
+urllib3==1.26.12 ; python_version != "3.4"
     # via
     #   -r requirements/tox-py36-cp36-win32-amd64.in
     #   requests

--- a/requirements/tox-py37-cp37-darwin-x86_64.txt
+++ b/requirements/tox-py37-cp37-darwin-x86_64.txt
@@ -136,7 +136,7 @@ typing-extensions==4.1.0
     # via
     #   importlib-metadata
     #   pydantic
-urllib3==1.26.8 ; python_version != "3.4"
+urllib3==1.26.12 ; python_version != "3.4"
     # via
     #   -r requirements/tox-py37-cp37-darwin-x86_64.in
     #   requests

--- a/requirements/tox-py37-cp37-linux-x86_64.txt
+++ b/requirements/tox-py37-cp37-linux-x86_64.txt
@@ -136,7 +136,7 @@ typing-extensions==4.1.0
     # via
     #   importlib-metadata
     #   pydantic
-urllib3==1.26.8 ; python_version != "3.4"
+urllib3==1.26.12 ; python_version != "3.4"
     # via
     #   -r requirements/tox-py37-cp37-linux-x86_64.in
     #   requests

--- a/requirements/tox-py37-cp37-win32-amd64.txt
+++ b/requirements/tox-py37-cp37-win32-amd64.txt
@@ -138,7 +138,7 @@ typing-extensions==4.1.0
     # via
     #   importlib-metadata
     #   pydantic
-urllib3==1.26.8 ; python_version != "3.4"
+urllib3==1.26.12 ; python_version != "3.4"
     # via
     #   -r requirements/tox-py37-cp37-win32-amd64.in
     #   requests

--- a/requirements/tox-py38-cp38-darwin-x86_64.txt
+++ b/requirements/tox-py38-cp38-darwin-x86_64.txt
@@ -129,7 +129,7 @@ trustme==0.9.0
     # via -r requirements/tox-py38-cp38-darwin-x86_64.in
 typing-extensions==4.3.0
     # via pydantic
-urllib3==1.26.8 ; python_version != "3.4"
+urllib3==1.26.12 ; python_version != "3.4"
     # via
     #   -r requirements/tox-py38-cp38-darwin-x86_64.in
     #   requests

--- a/requirements/tox-py38-cp38-linux-x86_64.txt
+++ b/requirements/tox-py38-cp38-linux-x86_64.txt
@@ -129,7 +129,7 @@ trustme==0.9.0
     # via -r requirements/tox-py38-cp38-linux-x86_64.in
 typing-extensions==4.3.0
     # via pydantic
-urllib3==1.26.8 ; python_version != "3.4"
+urllib3==1.26.12 ; python_version != "3.4"
     # via
     #   -r requirements/tox-py38-cp38-linux-x86_64.in
     #   requests

--- a/requirements/tox-py38-cp38-win32-amd64.txt
+++ b/requirements/tox-py38-cp38-win32-amd64.txt
@@ -131,7 +131,7 @@ trustme==0.9.0
     # via -r requirements/tox-py38-cp38-win32-amd64.in
 typing-extensions==4.3.0
     # via pydantic
-urllib3==1.26.8 ; python_version != "3.4"
+urllib3==1.26.12 ; python_version != "3.4"
     # via
     #   -r requirements/tox-py38-cp38-win32-amd64.in
     #   requests

--- a/requirements/tox-py39-cp39-darwin-x86_64.txt
+++ b/requirements/tox-py39-cp39-darwin-x86_64.txt
@@ -127,7 +127,7 @@ trustme==0.9.0
     # via -r requirements/tox-py39-cp39-darwin-x86_64.in
 typing-extensions==4.3.0
     # via pydantic
-urllib3==1.26.8 ; python_version != "3.4"
+urllib3==1.26.12 ; python_version != "3.4"
     # via
     #   -r requirements/tox-py39-cp39-darwin-x86_64.in
     #   requests

--- a/requirements/tox-py39-cp39-linux-x86_64.txt
+++ b/requirements/tox-py39-cp39-linux-x86_64.txt
@@ -127,7 +127,7 @@ trustme==0.9.0
     # via -r requirements/tox-py39-cp39-linux-x86_64.in
 typing-extensions==4.3.0
     # via pydantic
-urllib3==1.26.8 ; python_version != "3.4"
+urllib3==1.26.12 ; python_version != "3.4"
     # via
     #   -r requirements/tox-py39-cp39-linux-x86_64.in
     #   requests

--- a/requirements/tox-py39-cp39-win32-amd64.txt
+++ b/requirements/tox-py39-cp39-win32-amd64.txt
@@ -129,7 +129,7 @@ trustme==0.9.0
     # via -r requirements/tox-py39-cp39-win32-amd64.in
 typing-extensions==4.3.0
     # via pydantic
-urllib3==1.26.8 ; python_version != "3.4"
+urllib3==1.26.12 ; python_version != "3.4"
     # via
     #   -r requirements/tox-py39-cp39-win32-amd64.in
     #   requests

--- a/requirements/tox-pypy27-pp27-darwin-x86_64.txt
+++ b/requirements/tox-pypy27-pp27-darwin-x86_64.txt
@@ -180,7 +180,7 @@ typing==3.10.0.0
     # via
     #   importlib-resources
     #   pathlib2
-urllib3==1.26.8 ; python_version != "3.4"
+urllib3==1.26.12 ; python_version != "3.4"
     # via
     #   -r requirements/tox-pypy27-pp27-darwin-x86_64.in
     #   requests

--- a/requirements/tox-pypy27-pp27-linux-x86_64.txt
+++ b/requirements/tox-pypy27-pp27-linux-x86_64.txt
@@ -180,7 +180,7 @@ typing==3.10.0.0
     # via
     #   importlib-resources
     #   pathlib2
-urllib3==1.26.8 ; python_version != "3.4"
+urllib3==1.26.12 ; python_version != "3.4"
     # via
     #   -r requirements/tox-pypy27-pp27-linux-x86_64.in
     #   requests

--- a/requirements/tox-pypy27-pp27-win32-amd64.txt
+++ b/requirements/tox-pypy27-pp27-win32-amd64.txt
@@ -180,7 +180,7 @@ typing==3.10.0.0
     # via
     #   importlib-resources
     #   pathlib2
-urllib3==1.26.8 ; python_version != "3.4"
+urllib3==1.26.12 ; python_version != "3.4"
     # via
     #   -r requirements/tox-pypy27-pp27-win32-amd64.in
     #   requests

--- a/requirements/tox-pypy36-pp36-linux-x86_64.txt
+++ b/requirements/tox-pypy36-pp36-linux-x86_64.txt
@@ -129,7 +129,7 @@ trustme==0.9.0
     # via -r requirements/tox-pypy36-pp36-linux-x86_64.in
 typing-extensions==4.1.0
     # via importlib-metadata
-urllib3==1.26.8 ; python_version != "3.4"
+urllib3==1.26.12 ; python_version != "3.4"
     # via
     #   -r requirements/tox-pypy36-pp36-linux-x86_64.in
     #   requests

--- a/requirements/tox-pypy36-pp36-win32-amd64.txt
+++ b/requirements/tox-pypy36-pp36-win32-amd64.txt
@@ -131,7 +131,7 @@ trustme==0.9.0
     # via -r requirements/tox-pypy36-pp36-win32-amd64.in
 typing-extensions==4.1.0
     # via importlib-metadata
-urllib3==1.26.8 ; python_version != "3.4"
+urllib3==1.26.12 ; python_version != "3.4"
     # via
     #   -r requirements/tox-pypy36-pp36-win32-amd64.in
     #   requests

--- a/requirements/tox-pypy37-pp37-darwin-x86_64.txt
+++ b/requirements/tox-pypy37-pp37-darwin-x86_64.txt
@@ -138,7 +138,7 @@ typing-extensions==4.1.0
     # via
     #   importlib-metadata
     #   pydantic
-urllib3==1.26.8 ; python_version != "3.4"
+urllib3==1.26.12 ; python_version != "3.4"
     # via
     #   -r requirements/tox-pypy37-pp37-darwin-x86_64.in
     #   requests

--- a/requirements/tox-pypy37-pp37-linux-x86_64.txt
+++ b/requirements/tox-pypy37-pp37-linux-x86_64.txt
@@ -138,7 +138,7 @@ typing-extensions==4.1.0
     # via
     #   importlib-metadata
     #   pydantic
-urllib3==1.26.8 ; python_version != "3.4"
+urllib3==1.26.12 ; python_version != "3.4"
     # via
     #   -r requirements/tox-pypy37-pp37-linux-x86_64.in
     #   requests

--- a/requirements/tox-pypy37-pp37-win32-amd64.txt
+++ b/requirements/tox-pypy37-pp37-win32-amd64.txt
@@ -140,7 +140,7 @@ typing-extensions==4.1.0
     # via
     #   importlib-metadata
     #   pydantic
-urllib3==1.26.8 ; python_version != "3.4"
+urllib3==1.26.12 ; python_version != "3.4"
     # via
     #   -r requirements/tox-pypy37-pp37-win32-amd64.in
     #   requests


### PR DESCRIPTION
Automated pip-tools-managed pip constraint lockfiles update.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cherrypy/cheroot/514)
<!-- Reviewable:end -->
