### PR TITLE
Run Python commands in tox in isolated and strict mode

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -12,15 +12,20 @@ minversion = 3.14.0
 deps =
   -rrequirements/tests.in
 commands_pre =
-  {envpython} -m \
+  {envpython} \
+    {[python-cli-options]isolate} \
+    -m \
     OpenSSL.debug
 commands =
-  {envpython} -m \
+  {envpython} \
+    {[python-cli-options]isolate} \
+    -m \
     pytest \
     {tty:--color=yes} \
     {posargs:}
 install_command =
   {envpython} \
+    {[python-cli-options]isolate} \
     {toxinidir}/bin/pip-wrapper \
     '{envname}' \
     '{toxinidir}/requirements/' \
@@ -48,6 +53,12 @@ setenv =
   WEBTEST_INTERACTIVE=false
 
 
+[python-cli-options]
+# isolate = -I
+# FIXME: Python 2 shim. Is this equivalent to the above?
+isolate = -E -s
+
+
 [dists]
 setenv =
   PIP_CONSTRAINT = {toxinidir}/requirements/dist-build-constraints.txt
@@ -71,7 +82,9 @@ commands =
   # FIXME: instead of `{toxworkdir}/.tmp` that was added in tox v3.16.1.
   # NOTE: The last tox supporting Python 3.4 is 3.14.0
   # -d "{temp_dir}/.doctrees" \
-  {envpython} -m sphinx \
+  {envpython} \
+    {[python-cli-options]isolate} \
+    -m sphinx \
     -j auto \
     -b html \
     {tty:--color} \
@@ -83,7 +96,9 @@ commands =
     "{envdir}/docs_out"
 
   # Print out the output docs dir and a way to serve html:
-  -{envpython} -c\
+  -{envpython} \
+  {[python-cli-options]isolate} \
+  -c\
   'import pathlib;\
   docs_dir = pathlib.Path(r"{envdir}") / "docs_out";\
   index_file = docs_dir / "index.html";\
@@ -106,8 +121,10 @@ commands =
   -git fetch --unshallow
   -git fetch --tags
 
-  # Spellcheck docs site:
-  python -m sphinx \
+  # Doctest docs site:
+  {envpython} \
+    {[python-cli-options]isolate} \
+    -m sphinx \
     -j auto \
     -a -n -W \
     --keep-going \
@@ -129,8 +146,10 @@ commands =
   -git fetch --unshallow
   -git fetch --tags
 
-  # Spellcheck docs site:
-  python -m sphinx \
+  # Linkcheck docs site:
+  {envpython} \
+    {[python-cli-options]isolate} \
+    -m sphinx \
     -j auto \
     -a -n -W \
     --keep-going \
@@ -153,7 +172,9 @@ commands =
   -git fetch --tags
 
   # Spellcheck docs site:
-  python -m sphinx \
+  {envpython} \
+    {[python-cli-options]isolate} \
+    -m sphinx \
     -j auto \
     -a -n -W \
     --keep-going \
@@ -179,8 +200,12 @@ deps =
 usedevelop = False
 commands_pre =
 commands =
-  python -m twine check .tox/dist/*
-  python -m setuptools_scm ls
+  {envpython} \
+    {[python-cli-options]isolate} \
+    -m twine check .tox/dist/*
+  {envpython} \
+    {[python-cli-options]isolate} \
+    -m setuptools_scm ls
 
 
 [testenv:cleanup-dists]
@@ -193,7 +218,9 @@ setenv =
   {[dists]setenv}
 commands_pre =
 commands =
-  {envpython} -c \
+  {envpython} \
+  {[python-cli-options]isolate} \
+  -c \
     'import os, shutil, sys; dists_dir = os.getenv("PEP517_OUT_DIR"); shutil.rmtree(dists_dir, ignore_errors=True); sys.exit(os.path.exists(dists_dir))'
 
 
@@ -211,6 +238,7 @@ platform = darwin|linux
 install_command =
   env PIP_CONSTRAINT= \
     {envpython} \
+    {[python-cli-options]isolate} \
     {toxinidir}/bin/pip-wrapper \
     '{envname}' \
     '{toxinidir}/requirements/' \
@@ -231,7 +259,9 @@ commands =
   # if no format arguments are passed. This makes sure that
   # wheels are not dependent on the Git repo or anything
   # external what may be missing from sdist.
-  {envpython} -m build \
+  {envpython} \
+    {[python-cli-options]isolate} \
+    -m build \
     --outdir '{env:PEP517_OUT_DIR}/' \
     {posargs:{env:PEP517_BUILD_ARGS:}} \
     '{toxinidir}'
@@ -251,7 +281,9 @@ commands_pre =
 setenv =
   {[dists]setenv}
 commands =
-  {envpython} -m twine check \
+  {envpython} \
+    {[python-cli-options]isolate}
+    -m twine check \
     --strict \
     {env:PEP517_OUT_DIR}/*
 
@@ -267,6 +299,10 @@ setenv =
   TWINE_USERNAME = {env:TWINE_USERNAME:__token__}
 commands_pre =
 commands =
-  python -c "import path; path.Path('dist').rmtree_p()"
-  python -m pep517.build .
-  python -m twine upload dist/*
+  {envpython} \
+    {[python-cli-options]isolate} \
+    -c "import path; path.Path('dist').rmtree_p()"
+  {envpython} \
+    {[python-cli-options]isolate} -m pep517.build .
+  {envpython} \
+    {[python-cli-options]isolate} -m twine upload dist/*

--- a/tox.ini
+++ b/tox.ini
@@ -13,13 +13,13 @@ deps =
   -rrequirements/tests.in
 commands_pre =
   {envpython} \
-    {[python-cli-options]bytewarnings} \
+    {[python-cli-options]byteerrors} \
     {[python-cli-options]isolate} \
     -m \
     OpenSSL.debug
 commands =
   {envpython} \
-    {[python-cli-options]bytewarnings} \
+    {[python-cli-options]byteerrors} \
     {[python-cli-options]isolate} \
     -m \
     pytest \
@@ -27,7 +27,7 @@ commands =
     {posargs:}
 install_command =
   {envpython} \
-    {[python-cli-options]bytewarnings} \
+    {[python-cli-options]byteerrors} \
     {[python-cli-options]isolate} \
     {toxinidir}/bin/pip-wrapper \
     '{envname}' \
@@ -88,7 +88,7 @@ commands =
   # NOTE: The last tox supporting Python 3.4 is 3.14.0
   # -d "{temp_dir}/.doctrees" \
   {envpython} \
-    {[python-cli-options]bytewarnings} \
+    {[python-cli-options]byteerrors} \
     {[python-cli-options]isolate} \
     -m sphinx \
     -j auto \
@@ -103,7 +103,7 @@ commands =
 
   # Print out the output docs dir and a way to serve html:
   -{envpython} \
-  {[python-cli-options]bytewarnings} \
+  {[python-cli-options]byteerrors} \
   {[python-cli-options]isolate} \
   -c\
   'import pathlib;\
@@ -130,7 +130,7 @@ commands =
 
   # Doctest docs site:
   {envpython} \
-    {[python-cli-options]bytewarnings} \
+    {[python-cli-options]byteerrors} \
     {[python-cli-options]isolate} \
     -m sphinx \
     -j auto \
@@ -156,7 +156,7 @@ commands =
 
   # Linkcheck docs site:
   {envpython} \
-    {[python-cli-options]bytewarnings} \
+    {[python-cli-options]byteerrors} \
     {[python-cli-options]isolate} \
     -m sphinx \
     -j auto \
@@ -182,7 +182,7 @@ commands =
 
   # Spellcheck docs site:
   {envpython} \
-    {[python-cli-options]bytewarnings} \
+    {[python-cli-options]byteerrors} \
     {[python-cli-options]isolate} \
     -m sphinx \
     -j auto \
@@ -211,11 +211,11 @@ usedevelop = False
 commands_pre =
 commands =
   {envpython} \
-    {[python-cli-options]bytewarnings} \
+    {[python-cli-options]byteerrors} \
     {[python-cli-options]isolate} \
     -m twine check .tox/dist/*
   {envpython} \
-    {[python-cli-options]bytewarnings} \
+    {[python-cli-options]byteerrors} \
     {[python-cli-options]isolate} \
     -m setuptools_scm ls
 
@@ -231,7 +231,7 @@ setenv =
 commands_pre =
 commands =
   {envpython} \
-  {[python-cli-options]bytewarnings} \
+  {[python-cli-options]byteerrors} \
   {[python-cli-options]isolate} \
   -c \
     'import os, shutil, sys; dists_dir = os.getenv("PEP517_OUT_DIR"); shutil.rmtree(dists_dir, ignore_errors=True); sys.exit(os.path.exists(dists_dir))'
@@ -251,7 +251,7 @@ platform = darwin|linux
 install_command =
   env PIP_CONSTRAINT= \
     {envpython} \
-    {[python-cli-options]bytewarnings} \
+    {[python-cli-options]byteerrors} \
     {[python-cli-options]isolate} \
     {toxinidir}/bin/pip-wrapper \
     '{envname}' \
@@ -274,7 +274,7 @@ commands =
   # wheels are not dependent on the Git repo or anything
   # external what may be missing from sdist.
   {envpython} \
-    {[python-cli-options]bytewarnings} \
+    {[python-cli-options]byteerrors} \
     {[python-cli-options]isolate} \
     -m build \
     --outdir '{env:PEP517_OUT_DIR}/' \
@@ -297,7 +297,7 @@ setenv =
   {[dists]setenv}
 commands =
   {envpython} \
-    {[python-cli-options]bytewarnings} \
+    {[python-cli-options]byteerrors} \
     {[python-cli-options]isolate}
     -m twine check \
     --strict \
@@ -316,12 +316,12 @@ setenv =
 commands_pre =
 commands =
   {envpython} \
-    {[python-cli-options]bytewarnings} \
+    {[python-cli-options]byteerrors} \
     {[python-cli-options]isolate} \
     -c "import path; path.Path('dist').rmtree_p()"
   {envpython} \
-    {[python-cli-options]bytewarnings} \
+    {[python-cli-options]byteerrors} \
     {[python-cli-options]isolate} -m pep517.build .
   {envpython} \
-    {[python-cli-options]bytewarnings} \
+    {[python-cli-options]byteerrors} \
     {[python-cli-options]isolate} -m twine upload dist/*

--- a/tox.ini
+++ b/tox.ini
@@ -13,11 +13,13 @@ deps =
   -rrequirements/tests.in
 commands_pre =
   {envpython} \
+    {[python-cli-options]bytewarnings} \
     {[python-cli-options]isolate} \
     -m \
     OpenSSL.debug
 commands =
   {envpython} \
+    {[python-cli-options]bytewarnings} \
     {[python-cli-options]isolate} \
     -m \
     pytest \
@@ -25,6 +27,7 @@ commands =
     {posargs:}
 install_command =
   {envpython} \
+    {[python-cli-options]bytewarnings} \
     {[python-cli-options]isolate} \
     {toxinidir}/bin/pip-wrapper \
     '{envname}' \
@@ -54,6 +57,8 @@ setenv =
 
 
 [python-cli-options]
+byteerrors = -bb
+bytewarnings = -b
 # isolate = -I
 # FIXME: Python 2 shim. Is this equivalent to the above?
 isolate = -E -s
@@ -83,6 +88,7 @@ commands =
   # NOTE: The last tox supporting Python 3.4 is 3.14.0
   # -d "{temp_dir}/.doctrees" \
   {envpython} \
+    {[python-cli-options]bytewarnings} \
     {[python-cli-options]isolate} \
     -m sphinx \
     -j auto \
@@ -97,6 +103,7 @@ commands =
 
   # Print out the output docs dir and a way to serve html:
   -{envpython} \
+  {[python-cli-options]bytewarnings} \
   {[python-cli-options]isolate} \
   -c\
   'import pathlib;\
@@ -123,6 +130,7 @@ commands =
 
   # Doctest docs site:
   {envpython} \
+    {[python-cli-options]bytewarnings} \
     {[python-cli-options]isolate} \
     -m sphinx \
     -j auto \
@@ -148,6 +156,7 @@ commands =
 
   # Linkcheck docs site:
   {envpython} \
+    {[python-cli-options]bytewarnings} \
     {[python-cli-options]isolate} \
     -m sphinx \
     -j auto \
@@ -173,6 +182,7 @@ commands =
 
   # Spellcheck docs site:
   {envpython} \
+    {[python-cli-options]bytewarnings} \
     {[python-cli-options]isolate} \
     -m sphinx \
     -j auto \
@@ -201,9 +211,11 @@ usedevelop = False
 commands_pre =
 commands =
   {envpython} \
+    {[python-cli-options]bytewarnings} \
     {[python-cli-options]isolate} \
     -m twine check .tox/dist/*
   {envpython} \
+    {[python-cli-options]bytewarnings} \
     {[python-cli-options]isolate} \
     -m setuptools_scm ls
 
@@ -219,6 +231,7 @@ setenv =
 commands_pre =
 commands =
   {envpython} \
+  {[python-cli-options]bytewarnings} \
   {[python-cli-options]isolate} \
   -c \
     'import os, shutil, sys; dists_dir = os.getenv("PEP517_OUT_DIR"); shutil.rmtree(dists_dir, ignore_errors=True); sys.exit(os.path.exists(dists_dir))'
@@ -238,6 +251,7 @@ platform = darwin|linux
 install_command =
   env PIP_CONSTRAINT= \
     {envpython} \
+    {[python-cli-options]bytewarnings} \
     {[python-cli-options]isolate} \
     {toxinidir}/bin/pip-wrapper \
     '{envname}' \
@@ -260,6 +274,7 @@ commands =
   # wheels are not dependent on the Git repo or anything
   # external what may be missing from sdist.
   {envpython} \
+    {[python-cli-options]bytewarnings} \
     {[python-cli-options]isolate} \
     -m build \
     --outdir '{env:PEP517_OUT_DIR}/' \
@@ -282,6 +297,7 @@ setenv =
   {[dists]setenv}
 commands =
   {envpython} \
+    {[python-cli-options]bytewarnings} \
     {[python-cli-options]isolate}
     -m twine check \
     --strict \
@@ -300,9 +316,12 @@ setenv =
 commands_pre =
 commands =
   {envpython} \
+    {[python-cli-options]bytewarnings} \
     {[python-cli-options]isolate} \
     -c "import path; path.Path('dist').rmtree_p()"
   {envpython} \
+    {[python-cli-options]bytewarnings} \
     {[python-cli-options]isolate} -m pep517.build .
   {envpython} \
+    {[python-cli-options]bytewarnings} \
     {[python-cli-options]isolate} -m twine upload dist/*


### PR DESCRIPTION
❓ **What kind of change does this PR introduce?**

* [ ] 🐞 bug fix
* [ ] 🐣 feature
* [ ] 📋 docs update
* [x] 📋 tests/coverage improvement
* [x] 📋 refactoring
* [x] 💥 other

📋 **What is the related issue number (starting with `#`)**

N/A

❓ **What is the current behavior?** (You can also link to an open issue here)

Regular Python runs.

❓ **What is the new behavior (if this is a feature change)?**

Strict and isolated Python runs are embedded in tox.

📋 **Other information**:

N/A

📋 **Contribution checklist:**

(If you're a first-timer, check out
[this guide on making great pull requests][making a lovely PR])

* [x] I wrote descriptive pull request text above
* [x] I think the code is well written
* [x] I wrote [good commit messages]
* [x] I have [squashed related commits together][related squash] after
      the changes have been approved
* [ ] Unit tests for the changes exist
* [x] Integration tests for the changes exist (if applicable)
* [x] I used the same coding conventions as the rest of the project
* [x] The new code doesn't generate linter offenses
* [ ] Documentation reflects the changes
* [x] The PR relates to *only* one subject with a clear title
      and description in grammatically correct, complete sentences

[good commit messages]: http://chris.beams.io/posts/git-commit/
[making a lovely PR]: https://mtlynch.io/code-review-love/
[related squash]:
https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cherrypy/cheroot/562)
<!-- Reviewable:end -->
