### PR TITLE
Update type stubs to let `stubtest` succeed under Python 3.11

### DIFF
--- a/cheroot/ssl/__init__.pyi
+++ b/cheroot/ssl/__init__.pyi
@@ -1,7 +1,7 @@
-from abc import abstractmethod
+from abc import abstractmethod, ABCMeta
 from typing import Any
 
-class Adapter():
+class Adapter(metaclass=ABCMeta):
     certificate: Any
     private_key: Any
     certificate_chain: Any

--- a/requirements/tox-pre-commit-cp310-linux-x86_64.txt
+++ b/requirements/tox-pre-commit-cp310-linux-x86_64.txt
@@ -4,65 +4,61 @@
 #
 #    pip-compile --allow-unsafe --output-file=requirements/tox-pre-commit-cp310-linux-x86_64.txt --strip-extras requirements/tox-pre-commit-cp310-linux-x86_64.in setup.cfg
 #
-cffi==1.15.0
+cffi==1.15.1
     # via cryptography
 cfgv==3.3.1
     # via pre-commit
-cryptography==36.0.1
+cryptography==38.0.3
     # via pyopenssl
-distlib==0.3.4
+distlib==0.3.6
     # via virtualenv
-filelock==3.4.2
+filelock==3.8.0
     # via virtualenv
-identify==2.4.1
+identify==2.5.9
     # via pre-commit
-jaraco.functools==3.5.0
+jaraco-functools==3.5.2
     # via cheroot (setup.cfg)
-more-itertools==8.12.0 ; python_version >= "3.6"
+more-itertools==9.0.0
     # via
     #   cheroot (setup.cfg)
-    #   jaraco.functools
-mypy==0.931
+    #   jaraco-functools
+mypy==0.991
     # via -r requirements/tox-pre-commit-cp310-linux-x86_64.in
 mypy-extensions==0.4.3
     # via mypy
-nodeenv==1.6.0
+nodeenv==1.7.0
     # via pre-commit
-platformdirs==2.4.1
+platformdirs==2.5.4
     # via virtualenv
-pre-commit==2.16.0
+pre-commit==2.20.0
     # via -r requirements/tox-pre-commit-cp310-linux-x86_64.in
 pycparser==2.21
     # via cffi
-pyopenssl==22.0.0
+pyopenssl==22.1.0
     # via -r requirements/tox-pre-commit-cp310-linux-x86_64.in
 pyyaml==6.0
     # via pre-commit
-six==1.16.0
-    # via
-    #   cheroot (setup.cfg)
-    #   virtualenv
 toml==0.10.2
     # via pre-commit
-tomli==2.0.0
+tomli==2.0.1
     # via mypy
 types-backports==0.1.3
     # via -r requirements/tox-pre-commit-cp310-linux-x86_64.in
-types-cryptography==3.3.14
+types-cryptography==3.3.23.2
     # via types-pyopenssl
-types-enum34==1.1.8
-    # via types-cryptography
-types-ipaddress==1.0.7
-    # via types-cryptography
-types-pyopenssl==21.0.3
+types-pyopenssl==22.1.0.2
     # via -r requirements/tox-pre-commit-cp310-linux-x86_64.in
-types-requests==2.27.7
+types-requests==2.28.11.5
     # via -r requirements/tox-pre-commit-cp310-linux-x86_64.in
-types-six==1.16.10
+types-six==1.16.21.4
     # via -r requirements/tox-pre-commit-cp310-linux-x86_64.in
-types-urllib3==1.26.7
+types-urllib3==1.26.25.4
     # via types-requests
-typing-extensions==4.0.1
+typing-extensions==4.4.0
     # via mypy
-virtualenv==20.13.0
+virtualenv==20.16.7
     # via pre-commit
+
+# The following packages are considered to be unsafe in a requirements file:
+setuptools==65.6.0
+    # via nodeenv

--- a/requirements/tox-pre-commit-cp311-linux-x86_64.txt
+++ b/requirements/tox-pre-commit-cp311-linux-x86_64.txt
@@ -14,7 +14,7 @@ distlib==0.3.6
     # via virtualenv
 filelock==3.8.0
     # via virtualenv
-identify==2.5.8
+identify==2.5.9
     # via pre-commit
 jaraco-functools==3.5.2
     # via cheroot (setup.cfg)
@@ -22,13 +22,13 @@ more-itertools==9.0.0 ; python_version >= "3.6"
     # via
     #   cheroot (setup.cfg)
     #   jaraco-functools
-mypy==0.990
+mypy==0.991
     # via -r requirements/tox-pre-commit-cp311-linux-x86_64.in
 mypy-extensions==0.4.3
     # via mypy
 nodeenv==1.7.0
     # via pre-commit
-platformdirs==2.5.3
+platformdirs==2.5.4
     # via virtualenv
 pre-commit==2.20.0
     # via -r requirements/tox-pre-commit-cp311-linux-x86_64.in
@@ -48,17 +48,17 @@ types-cryptography==3.3.23.2
     # via types-pyopenssl
 types-pyopenssl==22.1.0.2
     # via -r requirements/tox-pre-commit-cp311-linux-x86_64.in
-types-requests==2.28.11.4
+types-requests==2.28.11.5
     # via -r requirements/tox-pre-commit-cp311-linux-x86_64.in
-types-six==1.16.21.2
+types-six==1.16.21.4
     # via -r requirements/tox-pre-commit-cp311-linux-x86_64.in
-types-urllib3==1.26.25.3
+types-urllib3==1.26.25.4
     # via types-requests
 typing-extensions==4.4.0
     # via mypy
-virtualenv==20.16.6
+virtualenv==20.16.7
     # via pre-commit
 
 # The following packages are considered to be unsafe in a requirements file:
-setuptools==65.5.1
+setuptools==65.6.0
     # via nodeenv

--- a/requirements/tox-pre-commit-cp39-linux-x86_64.txt
+++ b/requirements/tox-pre-commit-cp39-linux-x86_64.txt
@@ -4,65 +4,61 @@
 #
 #    pip-compile --allow-unsafe --output-file=requirements/tox-pre-commit-cp39-linux-x86_64.txt --strip-extras requirements/tox-pre-commit-cp39-linux-x86_64.in setup.cfg
 #
-cffi==1.15.0
+cffi==1.15.1
     # via cryptography
 cfgv==3.3.1
     # via pre-commit
-cryptography==36.0.1
+cryptography==38.0.3
     # via pyopenssl
-distlib==0.3.4
+distlib==0.3.6
     # via virtualenv
-filelock==3.4.2
+filelock==3.8.0
     # via virtualenv
-identify==2.4.1
+identify==2.5.9
     # via pre-commit
-jaraco.functools==3.5.0
+jaraco-functools==3.5.2
     # via cheroot (setup.cfg)
-more-itertools==8.12.0 ; python_version >= "3.6"
+more-itertools==9.0.0
     # via
     #   cheroot (setup.cfg)
-    #   jaraco.functools
-mypy==0.931
+    #   jaraco-functools
+mypy==0.991
     # via -r requirements/tox-pre-commit-cp39-linux-x86_64.in
 mypy-extensions==0.4.3
     # via mypy
-nodeenv==1.6.0
+nodeenv==1.7.0
     # via pre-commit
-platformdirs==2.4.1
+platformdirs==2.5.4
     # via virtualenv
-pre-commit==2.16.0
+pre-commit==2.20.0
     # via -r requirements/tox-pre-commit-cp39-linux-x86_64.in
 pycparser==2.21
     # via cffi
-pyopenssl==22.0.0
+pyopenssl==22.1.0
     # via -r requirements/tox-pre-commit-cp39-linux-x86_64.in
 pyyaml==6.0
     # via pre-commit
-six==1.16.0
-    # via
-    #   cheroot (setup.cfg)
-    #   virtualenv
 toml==0.10.2
     # via pre-commit
-tomli==2.0.0
+tomli==2.0.1
     # via mypy
 types-backports==0.1.3
     # via -r requirements/tox-pre-commit-cp39-linux-x86_64.in
-types-cryptography==3.3.14
+types-cryptography==3.3.23.2
     # via types-pyopenssl
-types-enum34==1.1.8
-    # via types-cryptography
-types-ipaddress==1.0.7
-    # via types-cryptography
-types-pyopenssl==21.0.3
+types-pyopenssl==22.1.0.2
     # via -r requirements/tox-pre-commit-cp39-linux-x86_64.in
-types-requests==2.27.7
+types-requests==2.28.11.5
     # via -r requirements/tox-pre-commit-cp39-linux-x86_64.in
-types-six==1.16.10
+types-six==1.16.21.4
     # via -r requirements/tox-pre-commit-cp39-linux-x86_64.in
-types-urllib3==1.26.7
+types-urllib3==1.26.25.4
     # via types-requests
-typing-extensions==4.0.1
+typing-extensions==4.4.0
     # via mypy
-virtualenv==20.13.0
+virtualenv==20.16.7
     # via pre-commit
+
+# The following packages are considered to be unsafe in a requirements file:
+setuptools==65.6.0
+    # via nodeenv

--- a/stubtest_allowlist.txt
+++ b/stubtest_allowlist.txt
@@ -41,3 +41,6 @@ cheroot.ssl.builtin.IS_ABOVE_OPENSSL10
 
 # suppress is both a function and class
 cheroot._compat.suppress
+
+# ignore test packages
+cheroot.test.*


### PR DESCRIPTION
❓ **What kind of change does this PR introduce?**

* [X] 🐞 bug fix
* [ ] 🐣 feature
* [ ] 📋 docs update
* [ ] 📋 tests/coverage improvement
* [ ] 📋 refactoring
* [ ] 💥 other

📋 **What is the related issue number (starting with `#`)**

<!-- Are there any issues opened that will be resolved by merging this change? -->
Resolves #567

❓ **What is the current behavior?** (You can also link to an open issue here)
stubtest fails with a bunch of errors


❓ **What is the new behavior (if this is a feature change)?**
subtest doesn't fail anymore

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cherrypy/cheroot/568)
<!-- Reviewable:end -->
