### PR TITLE
Stop tagging the wheel as `py2`

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -314,7 +314,7 @@ jobs:
                     steps.request-check.outputs.release-requested == 'true'
                     && github.event.inputs.release-version
                     || steps.scm-version.outputs.dist-version
-                }}-py2.py3-none-any.whl",
+                }}-py3-none-any.whl",
                 file=outputs_file,
             )
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,13 @@
 [bdist_wheel]
-universal = 1
+# NOTE: "universal = 1" causes `bdist_wheel` to create a wheel that with the
+# NOTE: tag "py2.py3" which implies (and tricks pip into thinking) that this
+# NOTE: wheel contains Python 2 compatible code. This is not true and conflicts
+# NOTE: with the "Requires-Python" field in the metadata that says that we only
+# NOTE: support Python 3.6+.
+# NOTE: We need to keep it at "0" which will produce wheels tagged with "py3"
+# NOTE: when built under Python 3.
+# Ref: https://github.com/pypa/packaging.python.org/issues/726
+universal = 0
 
 [metadata]
 name = cheroot


### PR DESCRIPTION
❓ **What kind of change does this PR introduce?**

* [x] 🐞 bug fix
* [x] 📋 refactoring
* [x] :package: packaging

📋 **What is the related issue number (starting with `#`)**

N/A

❓ **What is the current behavior?** (You can also link to an open issue here)

The published wheel artifacts are tagged as `py2.py3` which semantically means that they support Python 2 which conflicts the Require-Python value in the metadata.

❓ **What is the new behavior (if this is a feature change)?**

The configuration is changed to produce wheels tagged as just `py3`.

📋 **Other information**:

N/A

📋 **Contribution checklist:**

(If you're a first-timer, check out
[this guide on making great pull requests][making a lovely PR])

* [x] I wrote descriptive pull request text above
* [x] I think the code is well written
* [x] I wrote [good commit messages]
* [x] I have [squashed related commits together][related squash] after
      the changes have been approved
* [ ] Unit tests for the changes exist
* [x] Integration tests for the changes exist (if applicable)
* [x] I used the same coding conventions as the rest of the project
* [x] The new code doesn't generate linter offenses
* [ ] Documentation reflects the changes
* [x] The PR relates to *only* one subject with a clear title
      and description in grammatically correct, complete sentences

[good commit messages]: http://chris.beams.io/posts/git-commit/
[making a lovely PR]: https://mtlynch.io/code-review-love/
[related squash]:
https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cherrypy/cheroot/569)
<!-- Reviewable:end -->
