### PR TITLE
Fix the settings access in the `check` job @ GHA

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -885,6 +885,7 @@ jobs:
 
     needs:
     - lint
+    - pre-setup  # transitive, for accessing settings
     - tests
 
     runs-on: ubuntu-latest


### PR DESCRIPTION

❓ **What kind of change does this PR introduce?**

* [x] 🐞 bug fix
* [ ] 🐣 feature
* [ ] 📋 docs update
* [x] 📋 tests/coverage improvement
* [ ] 📋 refactoring
* [x] 💥 other

❓ **What is the current behavior?** (You can also link to an open issue here)

The `check` job in CI is broken — it crashes with the following error:
```console
Error: .github/workflows/ci-cd.yml (Line: 908, Col: 27):
Error: The template is not valid. .github/workflows/ci-cd.yml (Line: 908, Col: 27): Error reading JToken from JsonReader. Path '', line 0, position 0.
```

❓ **What is the new behavior (if this is a feature change)?**

This patch adds a transitive dependency on the `pre-setup` to the `check` job which effectively fixes the error that GitHub's YAML parser reports. That previous mistake was introduced earlier in https://github.com/webknjaz/cheroot/commit/23b3a580 and https://github.com/webknjaz/cheroot/commit/4ba0db10 — the initial implementation was referring to the outputs of the `pre-setup` job but it wasn't present in the `${{ needs }}` context.


📋 **Contribution checklist:**

(If you're a first-timer, check out
[this guide on making great pull requests][making a lovely PR])

* [x] I wrote descriptive pull request text above
* [x] I think the code is well written
* [x] I wrote [good commit messages]
* [x] I have [squashed related commits together][related squash] after
      the changes have been approved
* [ ] Unit tests for the changes exist
* [x] Integration tests for the changes exist (if applicable)
* [x] I used the same coding conventions as the rest of the project
* [x] The new code doesn't generate linter offenses
* [ ] Documentation reflects the changes
* [x] The PR relates to *only* one subject with a clear title
      and description in grammatically correct, complete sentences

[good commit messages]: http://chris.beams.io/posts/git-commit/
[making a lovely PR]: https://mtlynch.io/code-review-love/
[related squash]:
https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cherrypy/cheroot/576)
<!-- Reviewable:end -->
