### PR TITLE
Declare a separate setting `is-yolo-mode` in CI

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -112,6 +112,14 @@ jobs:
         ${{
             steps.request-check.outputs.release-requested || false
         }}
+      is-yolo-mode: >-
+        ${{
+          (
+            steps.request-check.outputs.release-requested == 'true'
+            && github.event.inputs.YOLO
+          )
+          && true || false
+        }}
       cache-key-files: >-
         ${{ steps.calc-cache-key-files.outputs.files-hash-key }}
       git-tag: ${{ steps.git-tag.outputs.tag }}
@@ -681,10 +689,7 @@ jobs:
     continue-on-error: >-
       ${{
           (
-            (
-              fromJSON(needs.pre-setup.outputs.release-requested) &&
-              !github.event.inputs.YOLO
-            ) ||
+            fromJSON(needs.pre-setup.outputs.is-yolo-mode) ||
             (
               startsWith(matrix.python-version, '~')
             ) ||
@@ -896,10 +901,8 @@ jobs:
       with:
         allowed-failures: >-
           ${{
-            (
-              fromJSON(needs.pre-setup.outputs.release-requested)
-              && github.event.inputs.YOLO
-            ) && 'lint, tests' || ''
+            fromJSON(needs.pre-setup.outputs.is-yolo-mode)
+            && 'lint, tests' || ''
           }}
         jobs: ${{ toJSON(needs) }}
 


### PR DESCRIPTION
❓ **What kind of change does this PR introduce?**

* [ ] 🐞 bug fix
* [ ] 🐣 feature
* [ ] 📋 docs update
* [ ] 📋 tests/coverage improvement
* [x] 📋 refactoring
* [x] 💥 other

❓ **What is the new behavior (if this is a feature change)?**

This is just a small CI refactoring, introducing a flag variable for the YOLO mode.

📋 **Contribution checklist:**

(If you're a first-timer, check out
[this guide on making great pull requests][making a lovely PR])

* [x] I wrote descriptive pull request text above
* [x] I think the code is well written
* [x] I wrote [good commit messages]
* [x] I have [squashed related commits together][related squash] after
      the changes have been approved
* [ ] Unit tests for the changes exist
* [x] Integration tests for the changes exist (if applicable)
* [x] I used the same coding conventions as the rest of the project
* [x] The new code doesn't generate linter offenses
* [ ] Documentation reflects the changes
* [x] The PR relates to *only* one subject with a clear title
      and description in grammatically correct, complete sentences

[good commit messages]: http://chris.beams.io/posts/git-commit/
[making a lovely PR]: https://mtlynch.io/code-review-love/
[related squash]:
https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cherrypy/cheroot/577)
<!-- Reviewable:end -->
