### PR TITLE
Integrate the `pytest-clarity` plugin for testing

### DIFF
--- a/requirements/tests.in
+++ b/requirements/tests.in
@@ -32,6 +32,7 @@ pyopenssl < 22.0.0; implementation_name == "pypy" and python_version < "3.8"
 # of the control flow:
 pypytools
 
+pytest-clarity
 pytest-cov==2.12.0
 pytest-forked>=1.2.0; sys_platform != "win32"
 pytest-mock>=1.11.0


### PR DESCRIPTION
❓ **What kind of change does this PR introduce?**

* [ ] 🐞 bug fix
* [ ] 🐣 feature
* [ ] 📋 docs update
* [x] 📋 tests/coverage improvement
* [ ] 📋 refactoring
* [ ] 💥 other

❓ **What is the new behavior (if this is a feature change)?**

This patch adds a pytest plugin that makes diffs in the failure output easier to read by coloring the divergence to in the data being asserted.
The plugin implements a diff mechanism from the Ward testing framework.

📋 **Other information**:

https://github.com/darrenburns/ward

📋 **Contribution checklist:**

(If you're a first-timer, check out
[this guide on making great pull requests][making a lovely PR])

* [x] I wrote descriptive pull request text above
* [ ] I think the code is well written
* [x] I wrote [good commit messages]
* [x] I have [squashed related commits together][related squash] after
      the changes have been approved
* [ ] Unit tests for the changes exist
* [x] Integration tests for the changes exist (if applicable)
* [x] I used the same coding conventions as the rest of the project
* [x] The new code doesn't generate linter offenses
* [ ] Documentation reflects the changes
* [x] The PR relates to *only* one subject with a clear title
      and description in grammatically correct, complete sentences

[good commit messages]: http://chris.beams.io/posts/git-commit/
[making a lovely PR]: https://mtlynch.io/code-review-love/
[related squash]:
https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cherrypy/cheroot/581)
<!-- Reviewable:end -->
