### PR TITLE
Use sdist for testing @ CI instead of Git checkout

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -52,6 +52,8 @@ concurrency:
   cancel-in-progress: true
 
 env:
+  dists-artifact-name: python-package-distributions
+
   FORCE_COLOR: 1  # Request colored output from CLI tools supporting it
   MYPY_FORCE_COLOR: 1  # MyPy's color enforcement
   PIP_DISABLE_PIP_VERSION_CHECK: 1
@@ -500,7 +502,7 @@ jobs:
     - name: Store the distribution packages
       uses: actions/upload-artifact@v3
       with:
-        name: python-package-distributions
+        name: ${{ env.dists-artifact-name }}
         # NOTE: Exact expected file names are specified here
         # NOTE: as a safety measure — if anything weird ends
         # NOTE: up being in this dir or not all dists will be
@@ -550,10 +552,22 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
 
+    # NOTE: `pre-commit --show-diff-on-failure` and `sphinxcontrib-spellcheck`
+    # NOTE: with Git authors allowlist enabled both depend on the presence of a
+    # NOTE: Git repository.
     - name: Grab the source from Git
+      if: >-
+        contains(fromJSON('["pre-commit", "spellcheck-docs"]'), matrix.toxenv)
       uses: actions/checkout@v3
       with:
         ref: ${{ github.event.inputs.release-committish }}
+    - name: Retrieve the project source from an sdist inside the GHA artifact
+      if: >-
+        !contains(fromJSON('["pre-commit", "spellcheck-docs"]'), matrix.toxenv)
+      uses: re-actors/checkout-python-sdist@release/v1
+      with:
+        source-tarball-name: ${{ needs.pre-setup.outputs.sdist-artifact-name }}
+        workflow-artifact-name: ${{ env.dists-artifact-name }}
 
     - name: >-
         Calculate Python interpreter version hash value
@@ -608,7 +622,7 @@ jobs:
       if: matrix.toxenv == 'metadata-validation'
       uses: actions/download-artifact@v3
       with:
-        name: python-package-distributions
+        name: ${{ env.dists-artifact-name }}
         path: dist/
 
     - name: >-
@@ -720,10 +734,11 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
 
-    - name: Grab the source from Git
-      uses: actions/checkout@v3
+    - name: Retrieve the project source from an sdist inside the GHA artifact
+      uses: re-actors/checkout-python-sdist@release/v1
       with:
-        ref: ${{ github.event.inputs.release-commitish }}
+        source-tarball-name: ${{ needs.pre-setup.outputs.sdist-artifact-name }}
+        workflow-artifact-name: ${{ env.dists-artifact-name }}
 
     - name: Figure out if the interpreter ABI is stable
       id: py-abi
@@ -813,7 +828,7 @@ jobs:
     - name: Download all the dists
       uses: actions/download-artifact@v3
       with:
-        name: python-package-distributions
+        name: ${{ env.dists-artifact-name }}
         path: dist/
 
     - name: >-
@@ -974,7 +989,7 @@ jobs:
     - name: Download all the dists
       uses: actions/download-artifact@v3
       with:
-        name: python-package-distributions
+        name: ${{ env.dists-artifact-name }}
         path: dist/
     - name: >-
         Publish 🐍📦 ${{ needs.pre-setup.outputs.git-tag }} to PyPI
@@ -1003,7 +1018,7 @@ jobs:
     - name: Download all the dists
       uses: actions/download-artifact@v3
       with:
-        name: python-package-distributions
+        name: ${{ env.dists-artifact-name }}
         path: dist/
     - name: >-
         Publish 🐍📦  ${{ needs.pre-setup.outputs.git-tag }} to TestPyPI
@@ -1096,7 +1111,7 @@ jobs:
     - name: Download all the dists
       uses: actions/download-artifact@v3
       with:
-        name: python-package-distributions
+        name: ${{ env.dists-artifact-name }}
         path: dist/
 
     - name: >-


### PR DESCRIPTION
❓ **What kind of change does this PR introduce?**

* [ ] 🐞 bug fix
* [ ] 🐣 feature
* [ ] 📋 docs update
* [x] 📋 tests/coverage improvement
* [x] 📋 refactoring
* [x] 💥 other

❓ **What is the current behavior?** (You can also link to an open issue here)

A Git checkout is used for testing in CI.

❓ **What is the new behavior (if this is a feature change)?**

Actual sdist contents can be used in the testing jobs instead of Git.


📋 **Contribution checklist:**

(If you're a first-timer, check out
[this guide on making great pull requests][making a lovely PR])

* [x] I wrote descriptive pull request text above
* [x] I think the code is well written
* [ ] I wrote [good commit messages]
* [ ] I have [squashed related commits together][related squash] after
      the changes have been approved
* [ ] Unit tests for the changes exist
* [x] Integration tests for the changes exist (if applicable)
* [x] I used the same coding conventions as the rest of the project
* [x] The new code doesn't generate linter offenses
* [ ] Documentation reflects the changes
* [x] The PR relates to *only* one subject with a clear title
      and description in grammatically correct, complete sentences

[good commit messages]: http://chris.beams.io/posts/git-commit/
[making a lovely PR]: https://mtlynch.io/code-review-love/
[related squash]:
https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cherrypy/cheroot/587)
<!-- Reviewable:end -->
