### PR TITLE
Add Solaris support to the test suite

### DIFF
--- a/cheroot/_compat.py
+++ b/cheroot/_compat.py
@@ -24,6 +24,7 @@ SYS_PLATFORM = platform.system()
 IS_WINDOWS = SYS_PLATFORM == 'Windows'
 IS_LINUX = SYS_PLATFORM == 'Linux'
 IS_MACOS = SYS_PLATFORM == 'Darwin'
+IS_SOLARIS = SYS_PLATFORM == 'SunOS'
 
 PLATFORM_ARCH = platform.machine()
 IS_PPC = PLATFORM_ARCH.startswith('ppc')

--- a/cheroot/_compat.pyi
+++ b/cheroot/_compat.pyi
@@ -10,6 +10,7 @@ SYS_PLATFORM: str
 IS_WINDOWS: bool
 IS_LINUX: bool
 IS_MACOS: bool
+IS_SOLARIS: bool
 PLATFORM_ARCH: str
 IS_PPC: bool
 

--- a/cheroot/test/test_errors.py
+++ b/cheroot/test/test_errors.py
@@ -4,7 +4,7 @@ import pytest
 
 from cheroot import errors
 
-from .._compat import IS_LINUX, IS_MACOS, IS_WINDOWS  # noqa: WPS130
+from .._compat import IS_LINUX, IS_MACOS, IS_SOLARIS, IS_WINDOWS  # noqa: WPS130
 
 
 @pytest.mark.parametrize(
@@ -18,6 +18,7 @@ from .._compat import IS_LINUX, IS_MACOS, IS_WINDOWS  # noqa: WPS130
             ),
             (91, 11, 32) if IS_LINUX else
             (32, 35, 41) if IS_MACOS else
+            (98, 11, 32) if IS_SOLARIS else
             (32, 10041, 11, 10035) if IS_WINDOWS else
             (),
         ),


### PR DESCRIPTION
❓ **What kind of change does this PR introduce?**

* [ ] 🐞 bug fix
* [ ] 🐣 feature
* [ ] 📋 docs update
* [X] 📋 tests/coverage improvement (technically it is)
* [ ] 📋 refactoring
* [ ] 💥 other

❓ **What is the current behavior?** (You can also link to an open issue here)
Currently, when running the test suite on Solaris, `test_plat_specific_errors` fails because platform specific error numbers are not known.

❓ **What is the new behavior (if this is a feature change)?**
With this patch, the test passes.

📋 **Contribution checklist:**

(If you're a first-timer, check out
[this guide on making great pull requests][making a lovely PR])

* [X] I wrote descriptive pull request text above
* [X] I think the code is well written
* [X] I wrote [good commit messages]
* [X] I have [squashed related commits together][related squash] after
      the changes have been approved
* [X] Unit tests for the changes exist (sure)
* [X] Integration tests for the changes exist (if applicable)
* [X] I used the same coding conventions as the rest of the project
* [X] The new code doesn't generate linter offenses
* [ ] Documentation reflects the changes
* [X] The PR relates to *only* one subject with a clear title
      and description in grammatically correct, complete sentences

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cherrypy/cheroot/627)
<!-- Reviewable:end -->
