### PR TITLE
💅 Address all instances of `BytesWarning`

### DIFF
--- a/cheroot/server.py
+++ b/cheroot/server.py
@@ -209,7 +209,11 @@ class HeaderReader:
             if not line.endswith(CRLF):
                 raise ValueError('HTTP requires CRLF terminators')
 
-            if line[0] in (SPACE, TAB):
+            if line[:1] in (SPACE, TAB):
+                # NOTE: `type(line[0]) is int` and `type(line[:1]) is bytes`.
+                # NOTE: The former causes a the following warning:
+                # NOTE: `BytesWarning('Comparison between bytes and int')`
+                # NOTE: The latter is equivalent and does not.
                 # It's a continuation line.
                 v = line.strip()
             else:

--- a/cheroot/test/test_conn.py
+++ b/cheroot/test/test_conn.py
@@ -53,7 +53,8 @@ class Controller(helper.Controller):
                 "'POST' != request.method %r" %
                 req.environ['REQUEST_METHOD'],
             )
-        return "thanks for '%s'" % req.environ['wsgi.input'].read()
+        input_contents = req.environ['wsgi.input'].read().decode('utf-8')
+        return f"thanks for '{input_contents !s}'"
 
     def custom_204(req, resp):
         """Render response with status 204."""
@@ -917,7 +918,7 @@ def test_100_Continue(test_client):
     status_line, _actual_headers, actual_resp_body = webtest.shb(response)
     actual_status = int(status_line[:3])
     assert actual_status == 200
-    expected_resp_body = ("thanks for '%s'" % body).encode()
+    expected_resp_body = f"thanks for '{body.decode() !s}'".encode()
     assert actual_resp_body == expected_resp_body
     conn.close()
 
@@ -987,7 +988,7 @@ def test_readall_or_close(test_client, max_request_body_size):
     status_line, actual_headers, actual_resp_body = webtest.shb(response)
     actual_status = int(status_line[:3])
     assert actual_status == 200
-    expected_resp_body = ("thanks for '%s'" % body).encode()
+    expected_resp_body = f"thanks for '{body.decode() !s}'".encode()
     assert actual_resp_body == expected_resp_body
     conn.close()
 


### PR DESCRIPTION
Things like byte-to-int comparisons and interpolation of bytes into str were present in the code base. This patch fixes that by making sure that the variables are always of compatible types in these cases.

❓ **What kind of change does this PR introduce?**

* [x] 🐞 bug fix
* [ ] 🐣 feature
* [ ] 📋 docs update
* [x] 📋 tests/coverage improvement
* [x] 📋 refactoring
* [x] 💥 other

📋 **What is the related issue number (starting with `#`)**

N/A

❓ **What is the current behavior?** (You can also link to an open issue here)

Currently, a `BytesWarning` is emitted. Mostly in tests, but there's one place where it's happening in the HTTP parser too.

❓ **What is the new behavior (if this is a feature change)?**

`BytesWarning` no more!

📋 **Other information**:

N/A

📋 **Contribution checklist:**

(If you're a first-timer, check out
[this guide on making great pull requests][making a lovely PR])

* [x] I wrote descriptive pull request text above
* [x] I think the code is well written
* [x] I wrote [good commit messages]
* [x] I have [squashed related commits together][related squash] after
      the changes have been approved
* [x] Unit tests for the changes exist
* [x] Integration tests for the changes exist (if applicable)
* [x] I used the same coding conventions as the rest of the project
* [x] The new code doesn't generate linter offenses
* [ ] Documentation reflects the changes
* [x] The PR relates to *only* one subject with a clear title
      and description in grammatically correct, complete sentences

[good commit messages]: http://chris.beams.io/posts/git-commit/
[making a lovely PR]: https://mtlynch.io/code-review-love/
[related squash]:
https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cherrypy/cheroot/648)
<!-- Reviewable:end -->
