### PR TITLE
🧪 Stop tagging codecov uploads w/ wheel name

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -909,8 +909,7 @@ jobs:
           }},
           Py-${{
             steps.python-install.outputs.python-version
-          }},
-          ${{ needs.pre-setup.outputs.wheel-artifact-name }}
+          }}
 
   check:  # This job does nothing and is only used for the branch protection
     if: always()


### PR DESCRIPTION
This seems to be what's breaking the uploader. It's likely because it's getting too long for Codecov to handle.

❓ **What kind of change does this PR introduce?**

* [ ] 🐞 bug fix
* [ ] 🐣 feature
* [ ] 📋 docs update
* [x] 📋 tests/coverage improvement
* [ ] 📋 refactoring
* [ ] 💥 other

📋 **What is the related issue number (starting with `#`)**

N/A

❓ **What is the current behavior?** (You can also link to an open issue here)

Codecov uploads from GHA fail.

❓ **What is the new behavior (if this is a feature change)?**

Well, they shouldn't anymore.

📋 **Other information**:

Codecov is weird about what can be a flag name and they seem to have some length/char restrictions that they don't communicate clearly.

📋 **Contribution checklist:**

(If you're a first-timer, check out
[this guide on making great pull requests][making a lovely PR])

* [x] I wrote descriptive pull request text above
* [x] I think the code is well written
* [x] I wrote [good commit messages]
* [x] I have [squashed related commits together][related squash] after
      the changes have been approved
* [ ] Unit tests for the changes exist
* [x] Integration tests for the changes exist (if applicable)
* [x] I used the same coding conventions as the rest of the project
* [x] The new code doesn't generate linter offenses
* [ ] Documentation reflects the changes
* [x] The PR relates to *only* one subject with a clear title
      and description in grammatically correct, complete sentences

[good commit messages]: http://chris.beams.io/posts/git-commit/
[making a lovely PR]: https://mtlynch.io/code-review-love/
[related squash]:
https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cherrypy/cheroot/650)
<!-- Reviewable:end -->
