### PR TITLE
handle openssl3 error in ssl tests

### DIFF
--- a/cheroot/_compat.py
+++ b/cheroot/_compat.py
@@ -8,9 +8,11 @@ import platform
 try:
     import ssl
     IS_ABOVE_OPENSSL10 = ssl.OPENSSL_VERSION_INFO >= (1, 1)
+    IS_ABOVE_OPENSSL31 = ssl.OPENSSL_VERSION_INFO >= (3, 2)
     del ssl
 except ImportError:
     IS_ABOVE_OPENSSL10 = None
+    IS_ABOVE_OPENSSL31 = None
 
 
 IS_CI = bool(os.getenv('CI'))

--- a/cheroot/_compat.pyi
+++ b/cheroot/_compat.pyi
@@ -3,6 +3,7 @@ from typing import Any, ContextManager, Optional, Type, Union
 def suppress(*exceptions: Type[BaseException]) -> ContextManager[None]: ...
 
 IS_ABOVE_OPENSSL10: Optional[bool]
+IS_ABOVE_OPENSSL31: Optional[bool]
 IS_CI: bool
 IS_GITHUB_ACTIONS_WORKFLOW: bool
 IS_PYPY: bool

--- a/cheroot/test/test_ssl.py
+++ b/cheroot/test/test_ssl.py
@@ -597,9 +597,9 @@ def test_https_over_http_error(http_server, ip_addr):
             ),
         ).request('GET', '/')
     expected_substring = (
-      'record layer failure' if IS_ABOVE_OPENSSL31
-      else 'wrong version number' if IS_ABOVE_OPENSSL10
-      else 'unknown protocol'
+        'record layer failure' if IS_ABOVE_OPENSSL31
+        else 'wrong version number' if IS_ABOVE_OPENSSL10
+        else 'unknown protocol'
     )
     assert expected_substring in ssl_err.value.args[-1]
 

--- a/cheroot/test/test_ssl.py
+++ b/cheroot/test/test_ssl.py
@@ -17,7 +17,7 @@ import requests
 import trustme
 
 from .._compat import bton, ntob, ntou
-from .._compat import IS_ABOVE_OPENSSL10, IS_CI, IS_PYPY
+from .._compat import IS_ABOVE_OPENSSL10, IS_ABOVE_OPENSSL31, IS_CI, IS_PYPY
 from .._compat import IS_LINUX, IS_MACOS, IS_WINDOWS
 from ..server import HTTPServer, get_ssl_adapter_class
 from ..testing import (
@@ -597,8 +597,9 @@ def test_https_over_http_error(http_server, ip_addr):
             ),
         ).request('GET', '/')
     expected_substring = (
-        'wrong version number' if IS_ABOVE_OPENSSL10
-        else 'unknown protocol'
+      'record layer failure' if IS_ABOVE_OPENSSL31
+      else 'wrong version number' if IS_ABOVE_OPENSSL10
+      else 'unknown protocol'
     )
     assert expected_substring in ssl_err.value.args[-1]
 


### PR DESCRIPTION
Using OpenSSL 3, the expected error string caught in ssl tests has changed.
E       AssertionError: assert 'wrong version number' in '[SSL] record layer failure (_ssl.c:1000)'

This is already handled for OpenSSL pre-1.1 and gte-1.1, adding handling for OpenSSL 3+

Fixes: #645

❓ **What kind of change does this PR introduce?**

* [ ] 🐞 bug fix
* [ ] 🐣 feature
* [ ] 📋 docs update
* [x] 📋 tests/coverage improvement
* [ ] 📋 refactoring
* [ ] 💥 other


📋 **Contribution checklist:**

(If you're a first-timer, check out
[this guide on making great pull requests][making a lovely PR])

* [x] I wrote descriptive pull request text above
* [x] I think the code is well written
* [x] I wrote [good commit messages]
* [x] I have [squashed related commits together][related squash] after
      the changes have been approved
* [x] Unit tests for the changes exist
* [x] Integration tests for the changes exist (if applicable)
* [x] I used the same coding conventions as the rest of the project
* [x] The new code doesn't generate linter offenses
* [x] Documentation reflects the changes
* [x] The PR relates to *only* one subject with a clear title
      and description in grammatically correct, complete sentences

[good commit messages]: http://chris.beams.io/posts/git-commit/
[making a lovely PR]: https://mtlynch.io/code-review-love/
[related squash]:
https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cherrypy/cheroot/655)
<!-- Reviewable:end -->
