### PR TITLE
Bump setuptools pin to 69.5.1 @ all lockfiles

### DIFF
--- a/requirements/tox-linkcheck-docs-cp310-linux-x86_64.txt
+++ b/requirements/tox-linkcheck-docs-cp310-linux-x86_64.txt
@@ -191,7 +191,7 @@ watchdog==2.1.6
     # via pytest-watch
 
 # The following packages are considered to be unsafe in a requirements file:
-setuptools==60.5.0
+setuptools==69.5.1
     # via
     #   jaraco.packaging
     #   pytest-rerunfailures

--- a/requirements/tox-linkcheck-docs-cp311-linux-x86_64.txt
+++ b/requirements/tox-linkcheck-docs-cp311-linux-x86_64.txt
@@ -214,5 +214,5 @@ watchdog==2.1.9
     # via pytest-watch
 
 # The following packages are considered to be unsafe in a requirements file:
-setuptools==65.5.1
+setuptools==69.5.1
     # via pytest-rerunfailures

--- a/requirements/tox-linkcheck-docs-cp38-linux-x86_64.txt
+++ b/requirements/tox-linkcheck-docs-cp38-linux-x86_64.txt
@@ -195,7 +195,7 @@ zipp==3.7.0
     # via importlib-resources
 
 # The following packages are considered to be unsafe in a requirements file:
-setuptools==60.5.0
+setuptools==69.5.1
     # via
     #   jaraco.packaging
     #   pytest-rerunfailures

--- a/requirements/tox-linkcheck-docs-cp39-linux-x86_64.txt
+++ b/requirements/tox-linkcheck-docs-cp39-linux-x86_64.txt
@@ -191,7 +191,7 @@ watchdog==2.1.6
     # via pytest-watch
 
 # The following packages are considered to be unsafe in a requirements file:
-setuptools==60.5.0
+setuptools==69.5.1
     # via
     #   jaraco.packaging
     #   pytest-rerunfailures

--- a/requirements/tox-pre-commit-cp310-linux-x86_64.txt
+++ b/requirements/tox-pre-commit-cp310-linux-x86_64.txt
@@ -60,5 +60,5 @@ virtualenv==20.16.7
     # via pre-commit
 
 # The following packages are considered to be unsafe in a requirements file:
-setuptools==65.6.0
+setuptools==69.5.1
     # via nodeenv

--- a/requirements/tox-pre-commit-cp311-linux-x86_64.txt
+++ b/requirements/tox-pre-commit-cp311-linux-x86_64.txt
@@ -60,5 +60,5 @@ virtualenv==20.16.7
     # via pre-commit
 
 # The following packages are considered to be unsafe in a requirements file:
-setuptools==65.6.0
+setuptools==69.5.1
     # via nodeenv

--- a/requirements/tox-pre-commit-cp39-linux-x86_64.txt
+++ b/requirements/tox-pre-commit-cp39-linux-x86_64.txt
@@ -60,5 +60,5 @@ virtualenv==20.16.7
     # via pre-commit
 
 # The following packages are considered to be unsafe in a requirements file:
-setuptools==65.6.0
+setuptools==69.5.1
     # via nodeenv


### PR DESCRIPTION
This is done to keep the compatibility with newer `setuptools-scm`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cherrypy/cheroot/692)
<!-- Reviewable:end -->
