### PR TITLE
🧪 Stop using `pytest-forked`

### DIFF
--- a/cheroot/test/test_server.py
+++ b/cheroot/test/test_server.py
@@ -400,15 +400,6 @@ def test_reuse_port(http_server, ip_addr, mocker):
     assert spy.spy_exception is None
 
 
-ISSUE511 = IS_MACOS
-
-
-if not IS_WINDOWS and not ISSUE511:
-    test_high_number_of_file_descriptors = pytest.mark.forked(
-        test_high_number_of_file_descriptors,
-    )
-
-
 @pytest.fixture
 def _garbage_bin():
     """Disable garbage collection when this fixture is in use."""

--- a/docs/changelog-fragments.d/502.contrib.rst
+++ b/docs/changelog-fragments.d/502.contrib.rst
@@ -1,0 +1,1 @@
+703.contrib.rst

--- a/docs/changelog-fragments.d/511.contrib.rst
+++ b/docs/changelog-fragments.d/511.contrib.rst
@@ -1,0 +1,1 @@
+703.contrib.rst

--- a/docs/changelog-fragments.d/680.contrib.rst
+++ b/docs/changelog-fragments.d/680.contrib.rst
@@ -1,0 +1,1 @@
+703.contrib.rst

--- a/docs/changelog-fragments.d/681.contrib.rst
+++ b/docs/changelog-fragments.d/681.contrib.rst
@@ -1,0 +1,1 @@
+703.contrib.rst

--- a/docs/changelog-fragments.d/703.contrib.rst
+++ b/docs/changelog-fragments.d/703.contrib.rst
@@ -1,0 +1,15 @@
+The test infrastructure has been updated to stop using
+the ``pytest-forked`` plugin
+-- by :user:`jaraco` and :user:`webknjaz`.
+
+This plugin was causing problems with upgrading to modern
+versions of Pytest and it is not going to be fixed anytime
+soon.
+
+It was used in a test that interacts with the system
+resource limits under \*NIX environments in hopes to isolate
+the side effects caused by the preparatory code.
+
+It is possible that this will have an effect on the test
+sessions and we may have to look for alternative solutions
+for test process isolation.

--- a/requirements/tests.in
+++ b/requirements/tests.in
@@ -34,18 +34,15 @@ pypytools
 
 pytest-clarity
 pytest-cov==2.12.0
-pytest-forked>=1.2.0; sys_platform != "win32"
 pytest-mock>=1.11.0
 pytest-rerunfailures
 pytest-sugar>=0.9.3
 pytest-watch==4.2.0
 pytest-xdist>=1.28.0
 
-# pytest-forked is currently incompatible with pytest 7
-# Refs:
-# * https://github.com/cherrypy/cheroot/issues/511
-# * https://github.com/pytest-dev/pytest-forked/issues/67
-pytest >= 4.6.6, < 7
+# pytest 7.2 introduces deprecations triggered by pytest-cov
+# * https://github.com/cherrypy/cheroot/issues/682
+pytest >= 7, <7.2
 
 # HTTP over UNIX socket
 requests-unixsocket


### PR DESCRIPTION
This plugin is incompatible with Pytest 7+, it's difficult to fix upstream and there is no timeline for addressing that.

The patch also bumps the top version boundary of Pytest to 7.2 due to the pinned `pytest-cov` raising warnings.

Fixes #502
Resolves #511
Closes #680
Resolves #681

❓ **What kind of change does this PR introduce?**

* [ ] 🐞 bug fix
* [ ] 🐣 feature
* [ ] 📋 docs update
* [x] 📋 tests/coverage improvement
* [ ] 📋 refactoring
* [x] 💥 other

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cherrypy/cheroot/703)
<!-- Reviewable:end -->
