### PR TITLE
Respond 400 instead of 500 when first header field line starts with SP or HTAB

### DIFF
--- a/cheroot/server.py
+++ b/cheroot/server.py
@@ -221,6 +221,7 @@ class HeaderReader:
         if hdict is None:
             hdict = {}
 
+        k = None
         hname = None
         while True:
             line = rfile.readline()
@@ -240,6 +241,8 @@ class HeaderReader:
                 # NOTE: `BytesWarning('Comparison between bytes and int')`
                 # NOTE: The latter is equivalent and does not.
                 # It's a continuation line.
+                if k is None:
+                    raise ValueError('Illegal continuation line.')
                 v = line.strip()
             else:
                 try:

--- a/cheroot/test/test_core.py
+++ b/cheroot/test/test_core.py
@@ -399,6 +399,18 @@ def test_request_line_split_issue_1220(test_client):
     assert actual_resp_body == b'Hello world!'
 
 
+def test_parse_invalid_line_fold(test_client):
+    """Check that the first field line can't begin with whitespace."""
+    c = test_client.get_connection()
+    c._output(u'GET / HTTP/1.1\r\n invalid\r\n\r\n'.encode('utf-8'))
+    c._send_output()
+    response = _get_http_response(c, method='GET')
+    response.begin()
+    assert response.status == HTTP_BAD_REQUEST
+    assert response.read(26) == b'Illegal continuation line.'
+    c.close()
+
+
 def test_garbage_in(test_client):
     """Test that server sends an error for garbage received over TCP."""
     # Connect without SSL regardless of server.scheme

--- a/cheroot/test/test_core.py
+++ b/cheroot/test/test_core.py
@@ -402,7 +402,7 @@ def test_request_line_split_issue_1220(test_client):
 def test_parse_invalid_line_fold(test_client):
     """Check that the first field line can't begin with whitespace."""
     c = test_client.get_connection()
-    c._output(u'GET / HTTP/1.1\r\n invalid\r\n\r\n'.encode('utf-8'))
+    c._output(b'GET / HTTP/1.1\r\n invalid\r\n\r\n')
     c._send_output()
     response = _get_http_response(c, method='GET')
     response.begin()

--- a/docs/changelog-fragments.d/728.bugfix.rst
+++ b/docs/changelog-fragments.d/728.bugfix.rst
@@ -1,0 +1,4 @@
+The server has been updated to respond 400 to requests in
+which the first header field line begins with whitespace,
+instead of 500.
+by :user:`kenballus`


### PR DESCRIPTION
❓ **What kind of change does this PR introduce?**

* [x] 🐞 bug fix
* [ ] 🐣 feature
* [ ] 📋 docs update
* [ ] 📋 tests/coverage improvement
* [ ] 📋 refactoring
* [ ] 💥 other

📋 **What is the related issue number (starting with `#`)**
#728 

❓ **What is the current behavior?** (You can also link to an open issue here)
Cheroot responds 500 when it receives a request in which the first header field line starts with SP or HTAB, due to an `UnboundLocalError`.

❓ **What is the new behavior (if this is a feature change)?**
It responds 400 instead.

📋 **Contribution checklist:**

(If you're a first-timer, check out
[this guide on making great pull requests][making a lovely PR])

* [X] I wrote descriptive pull request text above
* [X] I think the code is well written
* [X] I wrote [good commit messages]
* [x] I have [squashed related commits together][related squash] after
      the changes have been approved
* [X] Unit tests for the changes exist
* [X] Integration tests for the changes exist (if applicable)
* [X] I used the same coding conventions as the rest of the project
* [x] The new code doesn't generate linter offenses
* [x] Documentation reflects the changes
* [X] The PR relates to *only* one subject with a clear title
      and description in grammatically correct, complete sentences

[good commit messages]: http://chris.beams.io/posts/git-commit/
[making a lovely PR]: https://mtlynch.io/code-review-love/
[related squash]:
https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cherrypy/cheroot/729)
<!-- Reviewable:end -->
