### PR TITLE
Suppress pytest.PytestUnraisableExceptionWarning raised in test cleanup

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -69,6 +69,11 @@ filterwarnings =
   ignore:unclosed <socket.socket fd=:ResourceWarning
   ignore:unclosed <ssl.SSLSocket fd=:ResourceWarning
 
+  # FIXME: Python 3.13 no longer ignores IOBase errors raised by the close(),
+  # FIXME: which exposed a possible race condition in test_conn test cleanup.
+  # Ref: https://github.com/cherrypy/cheroot/issues/734
+  ignore:Exception ignored in. <function IOBase.__del__:pytest.PytestUnraisableExceptionWarning
+
 junit_duration_report = call
 junit_family = xunit2
 junit_suite_name = cheroot_test_suite


### PR DESCRIPTION
❓ **What kind of change does this PR introduce?**

* [X] 🐞 bug fix
* [ ] 🐣 feature
* [ ] 📋 docs update
* [X] 📋 tests improvement
* [ ] 📋 refactoring
* [ ] 💥 other

📋 **What is the related issue number**

<!-- Are there any issues opened that will be resolved by merging this change? -->
Resolves #734<!-- issue number here -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cherrypy/cheroot/735)
<!-- Reviewable:end -->
