### PR TITLE
When connection queue is full, respond with a 503 error.

### DIFF
--- a/cheroot/test/test_server.py
+++ b/cheroot/test/test_server.py
@@ -8,6 +8,7 @@ import threading
 import types
 import urllib.parse  # noqa: WPS301
 import uuid
+from http import HTTPStatus
 
 import pytest
 
@@ -570,3 +571,36 @@ def test_threadpool_multistart_validation(monkeypatch):
         match='Threadpools can only be started once.',
     ):
         tp.start()
+
+
+def test_overload_results_in_suitable_http_error(request):
+    """A server that can't keep up with requests returns a 503 HTTP error."""
+    localhost = '127.0.0.1'
+    httpserver = HTTPServer(
+        bind_addr=(localhost, EPHEMERAL_PORT),
+        gateway=Gateway,
+    )
+    # Can only handle on request in parallel:
+    httpserver.requests = ThreadPool(
+        min=1,
+        max=1,
+        accepted_queue_size=1,
+        accepted_queue_timeout=0,
+        server=httpserver,
+    )
+
+    httpserver.prepare()
+    serve_thread = threading.Thread(target=httpserver.serve)
+    serve_thread.start()
+    request.addfinalizer(httpserver.stop)
+    # Stop the thread pool to ensure the queue fills up:
+    httpserver.requests.stop()
+
+    _host, port = httpserver.bind_addr
+
+    # Use up the very limited thread pool queue we've set up, so future
+    # requests fail:
+    httpserver.requests._queue.put(None)
+
+    response = requests.get(f'http://{localhost}:{port}', timeout=20)
+    assert response.status_code == HTTPStatus.SERVICE_UNAVAILABLE

--- a/docs/changelog-fragments.d/745.feature.rst
+++ b/docs/changelog-fragments.d/745.feature.rst
@@ -1,0 +1,4 @@
+When load is too high, Cheroot now responds with a 503 Service Unavailable HTTP error.
+Previously it silently closed the connection.
+
+-- by :user:`itamarst`


### PR DESCRIPTION
❓ **What kind of change does this PR introduce?**

* [ ] 🐞 bug fix
* [x] 🐣 feature
* [ ] 📋 docs update
* [ ] 📋 tests/coverage improvement
* [ ] 📋 refactoring
* [ ] 💥 other

❓ **What is the current behavior?** (You can also link to an open issue here)

When connections can't be handled, the connection is just closed.


❓ **What is the new behavior (if this is a feature change)?**

A 503 error is returned, as suggested in TODO comment in relevant part of the code.

Since writing to the socket is blocking, this is done in a thread.

📋 **Other information**:

For some reason OpenStack Ironic needs this apparently, I didn't dig into why.

📋 **Contribution checklist:**

(If you're a first-timer, check out
[this guide on making great pull requests][making a lovely PR])

* [x] I wrote descriptive pull request text above
* [x] I think the code is well written
* [x] I wrote [good commit messages]
* [x] I have [squashed related commits together][related squash] after
      the changes have been approved
* [x] Unit tests for the changes exist
* [ ] Integration tests for the changes exist (if applicable)
* [ ] I used the same coding conventions as the rest of the project
* [ ] The new code doesn't generate linter offenses
* [ ] Documentation reflects the changes
* [ ] The PR relates to *only* one subject with a clear title
      and description in grammatically correct, complete sentences

[good commit messages]: http://chris.beams.io/posts/git-commit/
[making a lovely PR]: https://mtlynch.io/code-review-love/
[related squash]:
https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cherrypy/cheroot/745)
<!-- Reviewable:end -->
