### PR TITLE
Fixed circular reference in HTTPConnection

### DIFF
--- a/docs/changelog-fragments.d/755.bugfix.rst
+++ b/docs/changelog-fragments.d/755.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed a circular reference on connection close that was not freed until the garbage collection.


### PR DESCRIPTION
❓ **What kind of change does this PR introduce?**

* [x] 🐞 bug fix
* [ ] 🐣 feature
* [ ] 📋 docs update
* [ ] 📋 tests/coverage improvement
* [ ] 📋 refactoring
* [ ] 💥 other

📋 **What is the related issue number (starting with `#`)**

<!-- Are there any issues opened that will be resolved by merging this change? -->
Resolves #746

❓ **What is the current behavior?** (You can also link to an open issue here)

The UNIX socket server's caching system for credentials involves a circular reference to `HTTPConnection`, even for an INET server. 

❓ **What is the new behavior (if this is a feature change)?**

The cache system is still in place, but now uses private attributes.

📋 **Other information**:



📋 **Contribution checklist:**

(If you're a first-timer, check out
[this guide on making great pull requests][making a lovely PR])

* [x] I wrote descriptive pull request text above
* [x] I think the code is well written
* [x] I wrote [good commit messages]
* [ ] I have [squashed related commits together][related squash] after
      the changes have been approved
* [ ] Unit tests for the changes exist
* [x] Integration tests for the changes exist (if applicable)
* [x] I used the same coding conventions as the rest of the project
* [x] The new code doesn't generate linter offenses
* [x] Documentation reflects the changes
* [x] The PR relates to *only* one subject with a clear title
      and description in grammatically correct, complete sentences

[good commit messages]: http://chris.beams.io/posts/git-commit/
[making a lovely PR]: https://mtlynch.io/code-review-love/
[related squash]:
https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cherrypy/cheroot/755)
<!-- Reviewable:end -->
