### PR TITLE
Remove obsolete warning ignore

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -48,19 +48,9 @@ faulthandler_timeout = 30
 filterwarnings =
   error
 
-  # FIXME: drop once certifi fixes their use of `importlib.resources`
-  # Ref: https://github.com/certifi/python-certifi/issues/183
-  ignore:path is deprecated. Use files.. instead. Refer to https.//importlib-resources.readthedocs.io/en/latest/using.html#migrating-from-legacy for migration advice.:DeprecationWarning:certifi.core
-
   # FIXME: Try to figure out what causes this and ensure that the socket
   # FIXME: gets closed.
   ignore:unclosed <socket.socket fd=:ResourceWarning
-  ignore:unclosed <ssl.SSLSocket fd=:ResourceWarning
-
-  # FIXME: Python 3.13 no longer ignores IOBase errors raised by the close(),
-  # FIXME: which exposed a possible race condition in test_conn test cleanup.
-  # Ref: https://github.com/cherrypy/cheroot/issues/734
-  ignore:Exception ignored in. <function IOBase.__del__:pytest.PytestUnraisableExceptionWarning
 
 # https://docs.pytest.org/en/stable/usage.html#creating-junitxml-format-files
 junit_duration_report = call


### PR DESCRIPTION
Confirmed via a sweep (using **uv**) across Python 3.10–3.13, `ignore:path is deprecated … :DeprecationWarning:certifi.core`, `ResourceWarning: unclosed <ssl.SSLSocket …>` and `PytestUnraisableExceptionWarning: Exception ignored in <function IOBase.__del__ …>` are now all obsolete warning ignores as the deprecations no longer trigger in any of these Python versions.

So far, on my test, these mentioned suppressions are safe to remove without any additional code changes, but let's see what the CI thinks.

❓ **What kind of change does this PR introduce?**

* [ ] 🐞 bug fix
* [ ] 🐣 feature
* [ ] 📋 docs update
* [x] 📋 tests/coverage improvement
* [ ] 📋 refactoring
* [ ] 💥 other

📋 **What is the related issue number (starting with `#`)**

Related to #768

❓ **What is the current behavior?** (You can also link to an open issue here)
Pytest is configured to suppress certain warnings (`DeprecationWarning`, `ResourceWarning`, `PytestUnraisableExceptionWarning`) that no longer occur on supported Python versions.


❓ **What is the new behavior (if this is a feature change)?**
Those warning ignores are removed; test output is cleaner, and we rely on CI to confirm no regressions.


📋 **Contribution checklist:**

(If you're a first-timer, check out
[this guide on making great pull requests][making a lovely PR])

* [x] I wrote descriptive pull request text above
* [x] I think the code is well written
* [x] I wrote [good commit messages]
* [x] I have [squashed related commits together][related squash] after
      the changes have been approved
* [x] Unit tests for the changes exist
* [x] Integration tests for the changes exist (if applicable)
* [x] I used the same coding conventions as the rest of the project
* [x] The new code doesn't generate linter offenses
* [x] Documentation reflects the changes
* [x] The PR relates to *only* one subject with a clear title
      and description in grammatically correct, complete sentences

[good commit messages]: http://chris.beams.io/posts/git-commit/
[making a lovely PR]: https://mtlynch.io/code-review-love/
[related squash]:
https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cherrypy/cheroot/772)
<!-- Reviewable:end -->
