### PR TITLE
Fix: Increase keepalive and HTTP request timeouts to prevent CI failures

### DIFF
--- a/cheroot/test/conftest.py
+++ b/cheroot/test/conftest.py
@@ -23,7 +23,7 @@ from ..testing import (  # noqa: F401  # pylint: disable=unused-import
 @pytest.fixture
 def http_request_timeout():
     """Return a common HTTP request timeout for tests with queries."""
-    computed_timeout = 0.1
+    computed_timeout = 0.5
 
     if IS_MACOS:
         computed_timeout *= 2

--- a/cheroot/test/test_conn.py
+++ b/cheroot/test/test_conn.py
@@ -504,7 +504,7 @@ def test_keepalive(test_client, http_server_protocol):
 
 def test_keepalive_conn_management(test_client):
     """Test management of Keep-Alive connections."""
-    test_client.server_instance.timeout = 2
+    test_client.server_instance.timeout = 3
 
     def connection():
         # Initialize a persistent HTTP connection

--- a/docs/changelog-fragments.d/777.contrib.rst
+++ b/docs/changelog-fragments.d/777.contrib.rst
@@ -1,0 +1,2 @@
+Increased timeout values ``test_client.server_instance.timeout`` and ``http_request_timeout``
+to make related tests more stable.


### PR DESCRIPTION
These fixes address:

1. The `test_keepalive_conn_management` test was intermittently failing in CI with `http.client.NotConnected`. This was due to the combined execution time of test logic and the explicit `time.sleep()` exceeding the server timeout (2.0s).

2. The http_request_timeout was also too short and causing failures in test_http_over_https_error().

This commit addresses the flakiness by increasing both timeout values.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cherrypy/cheroot/777)
<!-- Reviewable:end -->
