### PR TITLE
Daemonize the serve_unservicable thread

### DIFF
--- a/cheroot/server.py
+++ b/cheroot/server.py
@@ -1929,7 +1929,7 @@ class HTTPServer:
         # This thread will handle unservicable connections, as added to
         # self._unservicable_conns queue. It will run forever, until
         # self.stop() tells it to shut down.
-        threading.Thread(target=self._serve_unservicable).start()
+        threading.Thread(target=self._serve_unservicable, daemon=True).start()
 
         while self.ready and not self.interrupt:
             try:


### PR DESCRIPTION
In Python < 3.13, the code backfills a shutdown method for a queue, but this isn't complete; an existing get call is not interrupted by shutdown and this means that when the unservicable queue is empty, it never stops, preventing the system from stopping.  By daemonizing the unservicable thread, the server can stop and exit.

A better solution would probably involve copying a fair amount of code from Python 3.13's queue implementation.  In my opinion that isn't worth the maintenance burden.  If desired, perhaps we should only daemonize this thread on Python < 3.13.

❓ **What kind of change does this PR introduce?**

* [x] 🐞 bug fix
* [ ] 🐣 feature
* [ ] 📋 docs update
* [ ] 📋 tests/coverage improvement
* [ ] 📋 refactoring
* [ ] 💥 other

📋 **What is the related issue number (starting with `#`)**

Resolves #769

❓ **What is the current behavior?** (You can also link to an open issue here)

It is impossible to stop a server that has no pending unservicable requests on Python < 3.13.

❓ **What is the new behavior (if this is a feature change)?**

You can stop a server that has no pending unservicable requests.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cherrypy/cheroot/778)
<!-- Reviewable:end -->
