### PR TITLE
🧪 Run linters under Python 3.14 in CI

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -594,7 +594,9 @@ jobs:
         runner-vm-os:
         - ubuntu-latest
         python-version:
-        - 3.14
+        - |-
+          3.11
+          3.14
         toxenv:
         - pre-commit
         - metadata-validation


### PR DESCRIPTION
❓ **What kind of change does this PR introduce?**

* [ ] 🐞 bug fix
* [ ] 🐣 feature
* [ ] 📋 docs update
* [x] 📋 tests/coverage improvement
* [ ] 📋 refactoring
* [ ] 💥 other

❓ **What is the current behavior?** (You can also link to an open issue here)

`tox exec` in CI seems to pick up a wrong Python interpreter and fail on outdated module imports.

❓ **What is the new behavior (if this is a feature change)?**

The runtime's upgraded.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cherrypy/cheroot/782)
<!-- Reviewable:end -->
