### PR TITLE
Stabilize flaky `test_openssl_adapter_with_false_key_password`

### DIFF
--- a/cheroot/test/test_ssl.py
+++ b/cheroot/test/test_ssl.py
@@ -924,7 +924,10 @@ def test_openssl_adapter_with_false_key_password(
 
     with expected_warn, pytest.raises(
         OpenSSL.SSL.Error,
-        match=r'.+bad decrypt.+',
+        # Decode error has happened very rarely with Python 3.9 in MacOS.
+        # Might be caused by a random issue in file handling leading
+        # to interpretation of garbage characters in certificates.
+        match=r'.+\'(bad decrypt|decode error)\'.+',
     ):
         httpserver.prepare()
 


### PR DESCRIPTION
Sometimes the pyopenssl adapter tests failed with a different error message than expected. This patch adapts the regex to cover the new discovered error message.

❓ **What kind of change does this PR introduce?**

Fix to an occasionally failing test: `test_openssl_adapter_with_false_key_password`

* [ ] 🐞 bug fix
* [ ] 🐣 feature
* [ ] 📋 docs update
* [X] 📋 tests/coverage improvement
* [ ] 📋 refactoring
* [ ] 💥 other

📋 **What is the related issue number (starting with `#`)**

<!-- Are there any issues opened that will be resolved by merging this change? -->
This is a follow-up for https://github.com/cherrypy/cheroot/pull/752#discussion_r2485127496

❓ **What is the current behavior?** (You can also link to an open issue here)

The test fails occasionally with different error message than expected


❓ **What is the new behavior (if this is a feature change)?**

Extended the expected error message regex to cover the other use case too


📋 **Other information**:



📋 **Contribution checklist:**

(If you're a first-timer, check out
[this guide on making great pull requests][making a lovely PR])

* [X] I wrote descriptive pull request text above
* [X] I think the code is well written
* [X] I wrote [good commit messages]
* [x] I have [squashed related commits together][related squash] after
      the changes have been approved
* [x] Unit tests for the changes exist
* [x] Integration tests for the changes exist (if applicable)
* [X] I used the same coding conventions as the rest of the project
* [X] The new code doesn't generate linter offenses
* [x] Documentation reflects the changes
* [X] The PR relates to *only* one subject with a clear title
      and description in grammatically correct, complete sentences

[good commit messages]: http://chris.beams.io/posts/git-commit/
[making a lovely PR]: https://mtlynch.io/code-review-love/
[related squash]:
https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cherrypy/cheroot/791)
<!-- Reviewable:end -->
