### PR TITLE
Fix thread leak by switching to different Queue shutdown mechanism

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -148,7 +148,7 @@ repos:
   - id: name-tests-test
     args:
     - --django
-    exclude: cheroot/test/(helper|webtest|_pytest_plugin).py
+    exclude: cheroot/test/(helper|webtest|_pytest_plugin|threadleakcheck).py
     files: cheroot/test/.+\.py$
   - id: check-added-large-files
   - id: check-case-conflict

--- a/cheroot/test/threadleakcheck.py
+++ b/cheroot/test/threadleakcheck.py
@@ -1,0 +1,43 @@
+"""
+Make sure threads don't leak.
+
+Run in an isolated subprocess by ``test_server.py``, to ensure parallelism of
+any sort don't cause problems.
+"""
+
+import sys
+import threading
+import time
+
+from cheroot.server import Gateway, HTTPServer
+from cheroot.testing import (
+    ANY_INTERFACE_IPV4,
+    EPHEMERAL_PORT,
+    SUCCESSFUL_SUBPROCESS_EXIT,
+)
+
+
+SLEEP_INTERVAL = 0.2
+
+
+def check_for_leaks():
+    """Exit with special success code if no threads were leaked."""
+    before_serv = threading.active_count()
+    for _ in range(5):
+        httpserver = HTTPServer(
+            bind_addr=(ANY_INTERFACE_IPV4, EPHEMERAL_PORT),
+            gateway=Gateway,
+        )
+        with httpserver._run_in_thread():
+            time.sleep(SLEEP_INTERVAL)
+
+    leaked_threads = threading.active_count() - before_serv
+    if leaked_threads == 0:
+        sys.exit(SUCCESSFUL_SUBPROCESS_EXIT)
+    else:
+        # We leaked a thread:
+        sys.exit(f'Number of leaked threads: {leaked_threads}')
+
+
+if __name__ == '__main__':
+    check_for_leaks()

--- a/cheroot/testing.py
+++ b/cheroot/testing.py
@@ -19,6 +19,10 @@ NO_INTERFACE = None  # Using this or '' will cause an exception
 ANY_INTERFACE_IPV4 = '0.0.0.0'
 ANY_INTERFACE_IPV6 = '::'
 
+# We use special exit code to indicate success, rather than normal zero, so
+# the test doesn't acidentally pass:
+SUCCESSFUL_SUBPROCESS_EXIT = 23
+
 config = {
     cheroot.wsgi.Server: {
         'bind_addr': (NO_INTERFACE, EPHEMERAL_PORT),

--- a/docs/changelog-fragments.d/769.bugfix.rst
+++ b/docs/changelog-fragments.d/769.bugfix.rst
@@ -1,0 +1,1 @@
+794.bugfix.rst

--- a/docs/changelog-fragments.d/794.bugfix.rst
+++ b/docs/changelog-fragments.d/794.bugfix.rst
@@ -1,0 +1,7 @@
+The "service unavailable" thread is now turn down properly when
+the server is shut down -- by :user:`itamarst`.
+
+This fixes a regression in Cheroot originally introduced in v11.0.0
+that would manifest itself under Python 3.12 and older. In certain
+conditions like under CherryPy, it would also lead to hangs on
+tear-down.


### PR DESCRIPTION
Implementing correct `shutdown()` would involve copying too much code, so switch to the more traditional way of indicating shutdown to a thread reading from a `Queue`.

❓ **What kind of change does this PR introduce?**

* [x] 🐞 bug fix
* [ ] 🐣 feature
* [ ] 📋 docs update
* [ ] 📋 tests/coverage improvement
* [ ] 📋 refactoring
* [ ] 💥 other

📋 **What is the related issue number (starting with `#`)**

Resolves #769
Superseded and closes #778

❓ **What is the current behavior?** (You can also link to an open issue here)

The overload thread leaks in Python < 3.13.

❓ **What is the new behavior (if this is a feature change)?**

The thread no longer leaks.


📋 **Other information**:



📋 **Contribution checklist:**

(If you're a first-timer, check out
[this guide on making great pull requests][making a lovely PR])

* [x] I wrote descriptive pull request text above
* [x] I think the code is well written
* [ ] I wrote [good commit messages]
* [ ] I have [squashed related commits together][related squash] after
      the changes have been approved
* [ ] Unit tests for the changes exist
* [x] Integration tests for the changes exist (if applicable)
* [x] I used the same coding conventions as the rest of the project
* [x] The new code doesn't generate linter offenses
* [x] Documentation reflects the changes
* [x] The PR relates to *only* one subject with a clear title
      and description in grammatically correct, complete sentences

[good commit messages]: http://chris.beams.io/posts/git-commit/
[making a lovely PR]: https://mtlynch.io/code-review-love/
[related squash]:
https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit
