### PR TITLE
Fix manual prompt in pyopenssl adapter for private key password

### DIFF
--- a/cheroot/ssl/__init__.py
+++ b/cheroot/ssl/__init__.py
@@ -2,6 +2,7 @@
 
 import socket as _socket
 from abc import ABC, abstractmethod
+from getpass import getpass as _ask_for_password_interactively
 from warnings import warn as _warn
 
 from .. import errors as _errors
@@ -113,3 +114,8 @@ class Adapter(ABC):
     def makefile(self, sock, mode='r', bufsize=-1):
         """Return socket file object."""
         raise NotImplementedError  # pragma: no cover
+
+    def _prompt_for_tls_password(self) -> str:
+        """Prompt for encrypted private key password interactively."""
+        prompt = 'Enter PEM pass phrase: '
+        return _ask_for_password_interactively(prompt)

--- a/cheroot/ssl/__init__.pyi
+++ b/cheroot/ssl/__init__.pyi
@@ -1,3 +1,4 @@
+import collections.abc as _c
 import typing as _t
 from abc import ABC, abstractmethod
 
@@ -6,8 +7,9 @@ class Adapter(ABC):
     private_key: _t.Any
     certificate_chain: _t.Any
     ciphers: _t.Any
-    private_key_password: str | bytes | None
+    private_key_password: _c.Callable[[], bytes | str] | bytes | str | None
     context: _t.Any
+
     @abstractmethod
     def __init__(
         self,
@@ -16,7 +18,10 @@ class Adapter(ABC):
         certificate_chain: _t.Any | None = ...,
         ciphers: _t.Any | None = ...,
         *,
-        private_key_password: str | bytes | None = ...,
+        private_key_password: _c.Callable[[], bytes | str]
+        | bytes
+        | str
+        | None = ...,
     ): ...
     def bind(self, sock): ...
     @abstractmethod
@@ -25,3 +30,4 @@ class Adapter(ABC):
     def get_environ(self): ...
     @abstractmethod
     def makefile(self, sock, mode: str = ..., bufsize: int = ...): ...
+    def _prompt_for_tls_password(self) -> str: ...

--- a/cheroot/ssl/builtin.py
+++ b/cheroot/ssl/builtin.py
@@ -247,6 +247,9 @@ class BuiltinSSLAdapter(Adapter):
             private_key_password=private_key_password,
         )
 
+        if private_key_password is None:
+            private_key_password = self._prompt_for_tls_password
+
         self.context = ssl.create_default_context(
             purpose=ssl.Purpose.CLIENT_AUTH,
             cafile=certificate_chain,

--- a/cheroot/ssl/builtin.pyi
+++ b/cheroot/ssl/builtin.pyi
@@ -1,3 +1,4 @@
+import collections.abc as _c
 import typing as _t
 
 from . import Adapter
@@ -14,7 +15,10 @@ class BuiltinSSLAdapter(Adapter):
         certificate_chain: _t.Any | None = ...,
         ciphers: _t.Any | None = ...,
         *,
-        private_key_password: str | bytes | None = ...,
+        private_key_password: _c.Callable[[], bytes | str]
+        | bytes
+        | str
+        | None = ...,
     ) -> None: ...
     @property
     def context(self): ...

--- a/cheroot/ssl/pyopenssl.pyi
+++ b/cheroot/ssl/pyopenssl.pyi
@@ -1,3 +1,4 @@
+import collections.abc as _c
 import typing as _t
 
 from OpenSSL import SSL
@@ -32,14 +33,20 @@ class pyOpenSSLAdapter(Adapter):
         certificate_chain: _t.Any | None = ...,
         ciphers: _t.Any | None = ...,
         *,
-        private_key_password: str | bytes | None = ...,
+        private_key_password: _c.Callable[[], bytes | str]
+        | bytes
+        | str
+        | None = ...,
     ) -> None: ...
     def wrap(self, sock): ...
     def _password_callback(
         self,
         password_max_length: int,
-        _verify_twice: bool,
-        password: bytes | str | None,
+        verify_twice: bool,
+        password_or_callback: _c.Callable[[], bytes | str]
+        | bytes
+        | str
+        | None,
         /,
     ) -> bytes: ...
     def get_environ(self): ...

--- a/docs/changelog-fragments.d/798.bugfix.rst
+++ b/docs/changelog-fragments.d/798.bugfix.rst
@@ -1,0 +1,7 @@
+Fixed prompting for the encrypted private key password interactively,
+when the password in not set in the :py:attr:`private_key_password attribute
+<cheroot.ssl.pyopenssl.pyOpenSSLAdapter.private_key_password>` in the
+:py:class:`pyOpenSSL TLS adapter <cheroot.ssl.pyopenssl.pyOpenSSLAdapter>`.
+Also improved the private key password to accept the :py:class:`~collections.abc.Callable` type.
+
+-- by :user:`jatalahd`


### PR DESCRIPTION
If `pyopenssl` adapter is used with password protected private key and the manual entry option was not given, only a fail due to invalid password. The password callback used to also be triggered in the case where the `private_key_password` was `None`.

❓ **What kind of change does this PR introduce?**

* [x] 🐞 bug fix
* [ ] 🐣 feature
* [ ] 📋 docs update
* [ ] 📋 tests/coverage improvement
* [ ] 📋 refactoring
* [ ] 💥 other

📋 **What is the related issue number (starting with `#`)**

<!-- Are there any issues opened that will be resolved by merging this change? -->
Resolves #<!-- issue number here -->

❓ **What is the current behavior?** (You can also link to an open issue here)

Manual prompt to enter private key password is not given in server startup
in the case where private_key_password = None. Functionality conflicts with
documentation and with builtin adapter


❓ **What is the new behavior (if this is a feature change)?**

With this fix the functionality is matching the documentation
and both ssl adapters work in similar fashion.


📋 **Other information**:



📋 **Contribution checklist:**

(If you're a first-timer, check out
[this guide on making great pull requests][making a lovely PR])

* [x] I wrote descriptive pull request text above
* [x] I think the code is well written
* [x] I wrote [good commit messages]
* [x] I have [squashed related commits together][related squash] after
      the changes have been approved
* [ ] Unit tests for the changes exist
* [ ] Integration tests for the changes exist (if applicable)
* [x] I used the same coding conventions as the rest of the project
* [x] The new code doesn't generate linter offenses
* [x] Documentation reflects the changes
* [x] The PR relates to *only* one subject with a clear title
      and description in grammatically correct, complete sentences

[good commit messages]: http://chris.beams.io/posts/git-commit/
[making a lovely PR]: https://mtlynch.io/code-review-love/
[related squash]:
https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit
