### PR TITLE
Unify handling of http over https errors

### DIFF
--- a/cheroot/ssl/__init__.py
+++ b/cheroot/ssl/__init__.py
@@ -1,7 +1,57 @@
 """Implementation of the SSL adapter base interface."""
 
+import socket as _socket
 from abc import ABC, abstractmethod
 from warnings import warn as _warn
+
+from .. import errors as _errors
+
+
+def _ensure_peer_speaks_https(raw_socket, /) -> None:
+    """
+    Raise exception if the client sent plain HTTP.
+
+    This method probes the TCP stream for signs of the peer having
+    sent us plaintext HTTP on the HTTPS port by peeking at the
+    first bytes. If there's no data yet, the method considers the
+    guess inconclusive and does not error out. This allows the server
+    to continue until the SSL handshake is attempted, at which point
+    an error will be caught by the SSL layer if the client
+    is not speaking TLS.
+
+    :raises NoSSLError: When plaintext HTTP is detected on an HTTPS socket
+    """
+    PEEK_BYTES = 16
+    PEEK_TIMEOUT = 0.5
+
+    original_timeout = raw_socket.gettimeout()
+    raw_socket.settimeout(PEEK_TIMEOUT)
+
+    try:
+        first_bytes = raw_socket.recv(PEEK_BYTES, _socket.MSG_PEEK)
+    except (OSError, _socket.timeout):
+        return
+    finally:
+        raw_socket.settimeout(original_timeout)
+
+    if not first_bytes:
+        return
+
+    http_methods = (
+        b'GET ',
+        b'POST ',
+        b'PUT ',
+        b'DELETE ',
+        b'HEAD ',
+        b'OPTIONS ',
+        b'PATCH ',
+        b'CONNECT ',
+        b'TRACE ',
+    )
+    if first_bytes.startswith(http_methods):
+        raise _errors.NoSSLError(
+            'Expected HTTPS on the socket but got plain HTTP',
+        ) from None
 
 
 class Adapter(ABC):
@@ -51,7 +101,8 @@ class Adapter(ABC):
     @abstractmethod
     def wrap(self, sock):
         """Wrap the given socket and return WSGI environ entries."""
-        raise NotImplementedError  # pragma: no cover
+        _ensure_peer_speaks_https(sock)
+        return sock, {}
 
     @abstractmethod
     def get_environ(self):

--- a/cheroot/ssl/builtin.py
+++ b/cheroot/ssl/builtin.py
@@ -305,6 +305,10 @@ class BuiltinSSLAdapter(Adapter):
 
     def wrap(self, sock):
         """Wrap and return the given socket, plus WSGI environ entries."""
+        sock, _env = super().wrap(  # checks for plaintext http on https port
+            sock,
+        )
+
         try:
             s = self.context.wrap_socket(
                 sock,

--- a/cheroot/ssl/pyopenssl.py
+++ b/cheroot/ssl/pyopenssl.py
@@ -339,6 +339,11 @@ class pyOpenSSLAdapter(Adapter):
         # pyOpenSSL doesn't perform the handshake until the first read/write
         # forcing the handshake to complete tends to result in the connection
         # closing so we can't reliably access protocol/client cert for the env
+
+        sock, _env = super().wrap(  # checks for plaintext http on https port
+            sock,
+        )
+
         conn = SSLConnection(self.context, sock)
 
         conn.set_accept_state()  # Tell OpenSSL this is a server connection

--- a/docs/changelog-fragments.d/800.bugfix.1.rst
+++ b/docs/changelog-fragments.d/800.bugfix.1.rst
@@ -1,0 +1,5 @@
+Plaintext HTTP error responses on HTTPS ports now reliably send complete
+messages to clients using :meth:`~socket.socket.sendall` instead of buffered
+writes that may not flush before the connection closes.
+
+-- by :user:`julianz-`

--- a/docs/changelog-fragments.d/800.bugfix.2.rst
+++ b/docs/changelog-fragments.d/800.bugfix.2.rst
@@ -1,0 +1,7 @@
+The :py:mod:`cheroot.ssl.builtin` SSL adapter now responds with a
+``400 Bad Request`` error to plaintext HTTP requests on HTTPS ports by detecting
+them before the SSL handshake, matching the behavior of
+:py:mod:`cheroot.ssl.pyopenssl`. Previously, such requests would fail during
+the SSL handshake without sending an HTTP response.
+
+-- by :user:`julianz-`

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -40,6 +40,7 @@ netloc
 noqa
 PIL
 pipelining
+plaintext
 positionally
 pre
 preconfigure


### PR DESCRIPTION
Added an early probe to identify when a client attempts to speak unencrypted HTTP on an HTTPS port.

When a plaintext connection is detected, the server now attempts to use the raw TCP socket (if wrapped) to send a "400 Bad Request" error response before any TLS failure. This unifies the behavior of the 'builtin' and 'pyopenssl' adapters for this specific error condition.