### PR TITLE
Handle socket errors when sending HTTP-over-HTTPS error responses

### DIFF
--- a/cheroot/connections.py
+++ b/cheroot/connections.py
@@ -327,6 +327,8 @@ class ConnectionManager:
                     wfile = mf(s, 'wb', io.DEFAULT_BUFFER_SIZE)
                     try:
                         wfile.write(''.join(buf).encode('ISO-8859-1'))
+                        wfile.flush()
+                        wfile.close()
                     except OSError as ex:
                         if ex.args[0] not in errors.socket_errors_to_ignore:
                             raise

--- a/cheroot/server.py
+++ b/cheroot/server.py
@@ -1370,6 +1370,7 @@ class HTTPConnection:
             'this server only speaks HTTPS on this port.'
         )
         req.simple_response('400 Bad Request', msg)
+        self.wfile.flush()
         self.linger = True
 
     def _conditional_error(self, req, response):

--- a/cheroot/test/test_ssl.py
+++ b/cheroot/test/test_ssl.py
@@ -713,7 +713,6 @@ def test_https_over_http_error(http_server, ip_addr):
         pytest.param(ANY_INTERFACE_IPV6, marks=missing_ipv6),
     ),
 )
-@pytest.mark.flaky(reruns=3, reruns_delay=2)
 # pylint: disable-next=too-many-positional-arguments
 def test_http_over_https_error(
     http_request_timeout,
@@ -726,12 +725,6 @@ def test_http_over_https_error(
     tls_certificate_private_key_pem_path,
 ):
     """Ensure that connecting over HTTP to HTTPS port is handled."""
-    # disable some flaky tests
-    # https://github.com/cherrypy/cheroot/issues/225
-    issue_225 = IS_MACOS and adapter_type == 'builtin'
-    if issue_225:
-        pytest.xfail('Test fails in Travis-CI')
-
     if IS_LINUX:
         expected_error_code, expected_error_text = (
             104,

--- a/docs/changelog-fragments.d/802.bugfix.rst
+++ b/docs/changelog-fragments.d/802.bugfix.rst
@@ -1,0 +1,3 @@
+Fixed socket errors when clients send HTTP to HTTPS-only ports.
+
+-- by :user:`julianz-`

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -40,6 +40,7 @@ netloc
 noqa
 PIL
 pipelining
+plaintext
 positionally
 pre
 preconfigure


### PR DESCRIPTION
When a client sends plaintext HTTP to a TLS-only port, the SSL layer detects the invalid handshake and may close the underlying socket. The server attempts to send a 400 Bad Request error response, but the socket may already be closed, causing OSError during the flush.

With pyOpenSSL, the response usually succeeds. With the builtin SSL adapter, the socket is typically closed before the write can occur.

This fix overrides `_flush_unlocked()` in `StreamWriter` to catch `OSError` and clear the buffer. This allows:
- The explicit flush to fail gracefully when sending the 400 response
- Object finalization (`__del__`) to complete without errors

Note that swallowing OSErrors here should not affect normal communication: `write()` calls upon `_flush_unlocked()` in `StreamWriter` which in turn calls the base class implementation `_flush_unlocked` in BufferedWriter. The base implementation handles errors of type `BlockingIOError`  such as `WantWriteError` and `WantReadsError`. But if the socket is dead an OSError is raised which propagates up to `StreamWriter` where `_flush_unlocked()` now handles the error.