### PR TITLE
tests: silence a Python 3.14 specific warning; Mark Python 3.14 as being officially supported.

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -728,6 +728,7 @@ jobs:
         # NOTE: The latest and the lowest supported Pythons are prioritized
         # NOTE: to improve the responsiveness. It's nice to see the most
         # NOTE: important results first.
+        - 3.14
         - 3.13
         - 3.8
         - pypy-3.11
@@ -736,7 +737,7 @@ jobs:
         - >-
           3.10
         - 3.9
-        - ~3.14.0-0
+        - ~3.15.0-0
         runner-vm-os:
         - ubuntu-24.04-arm
         - ubuntu-24.04

--- a/.github/workflows/pip-tools.yml
+++ b/.github/workflows/pip-tools.yml
@@ -58,6 +58,7 @@ jobs:
         # NOTE: The latest and the lowest supported Pythons are prioritized
         # NOTE: to improve the responsiveness. It's nice to see the most
         # NOTE: important results first.
+        - 3.14
         - 3.13
         - 3.8
         - pypy-3.11
@@ -66,7 +67,7 @@ jobs:
         - >-
           3.10
         - 3.9
-        - ~3.14.0-0
+        - ~3.15.0-0
         os:
         - ubuntu-24.04-arm
         - macOS-15  # arm64

--- a/docs/changelog-fragments.d/767.contrib.rst
+++ b/docs/changelog-fragments.d/767.contrib.rst
@@ -1,0 +1,3 @@
+Tests: copied and adapted Python 3.13 filter warning for Python 3.14, to match
+the new syntax
+-- by :user:`mr-c`.

--- a/docs/changelog-fragments.d/767.packaging.rst
+++ b/docs/changelog-fragments.d/767.packaging.rst
@@ -1,0 +1,2 @@
+Declared Python version 3.14 as officially supported
+-- by :user:`mr-c`.

--- a/docs/changelog-fragments.d/810.contrib.rst
+++ b/docs/changelog-fragments.d/810.contrib.rst
@@ -1,0 +1,1 @@
+767.contrib.rst

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ classifiers = [
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
   "Programming Language :: Python :: Implementation",
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: Jython",

--- a/pytest.ini
+++ b/pytest.ini
@@ -61,6 +61,8 @@ filterwarnings =
   # FIXME: which exposed a possible race condition in test_conn test cleanup.
   # Ref: https://github.com/cherrypy/cheroot/issues/734
   ignore:Exception ignored in. <function IOBase.__del__:pytest.PytestUnraisableExceptionWarning
+  # Python 3.14 version of the above
+  ignore:Exception ignored while calling deallocator <function IOBase.__del__ at:pytest.PytestUnraisableExceptionWarning
 
 # https://docs.pytest.org/en/stable/usage.html#creating-junitxml-format-files
 junit_duration_report = call


### PR DESCRIPTION
Works towards: #767

For the Debian package of cheroot we need Python 3.14 support, and I noticed modifying and adapting the Python3.13 specific warning for Python 3.14 was enough to get the tests to pass with Python 3.14. 

❓ **What kind of change does this PR introduce?**

* [ ] 🐞 bug fix
* [ ] 🐣 feature
* [ ] 📋 docs update
* [x] 📋 tests/coverage improvement
* [ ] 📋 refactoring
* [ ] 💥 other

📋 **What is the related issue number (starting with `#`)**

<!-- Are there any issues opened that will be resolved by merging this change? -->
 #767 


📋 **Other information**:



📋 **Contribution checklist:**

(If you're a first-timer, check out
[this guide on making great pull requests][making a lovely PR])

* [x] I wrote descriptive pull request text above
* [x] I think the code is well written
* [x] I wrote [good commit messages]
* [x] I have [squashed related commits together][related squash] after
      the changes have been approved
* [x] Unit tests for the changes exist
* [x] Integration tests for the changes exist (if applicable)
* [x] I used the same coding conventions as the rest of the project
* [x] The new code doesn't generate linter offenses
* [x] Documentation reflects the changes
* [x] The PR relates to *only* one subject with a clear title
      and description in grammatically correct, complete sentences

[good commit messages]: http://chris.beams.io/posts/git-commit/
[making a lovely PR]: https://mtlynch.io/code-review-love/
[related squash]:
https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit
