### PR TITLE
docs: adjust intersphinx links & fix building docs with Python 3.14

### DIFF
--- a/dependencies/tox-docs-constraints.in
+++ b/dependencies/tox-docs-constraints.in
@@ -1,0 +1,17 @@
+###############################################################################
+#                                                                             #
+# This file is only meant to exclude broken dependency versions, not feature  #
+# dependencies.                                                               #
+#                                                                             #
+# GUIDELINES:                                                                 #
+#   1. Only list PyPI project versions that need to be excluded using `!=`    #
+#      and `<`.                                                               #
+#   2. It is allowed to have transitive dependency limitations in this file.  #
+#   3. Apply bare minimum constraints under narrow conditions, use            #
+#      environment markers if possible. E.g.  `; python_version < "3.12"`.    #
+#   4. Whenever there are no constraints, let the file and this header        #
+#      remain in Git.                                                         #
+#                                                                             #
+###############################################################################
+
+docutils < 0.22  # https://github.com/executablebooks/sphinx-tabs/pull/207

--- a/dependencies/tox-docs.in
+++ b/dependencies/tox-docs.in
@@ -1,3 +1,4 @@
+-c tox-docs-constraints.in  # limits known broken versions
 -r tests.in  # `sphinxcontrib-autodoc` will import all the files
 
 Sphinx >= 1.8.2

--- a/docs/changelog-fragments.d/811.contrib.rst
+++ b/docs/changelog-fragments.d/811.contrib.rst
@@ -1,0 +1,3 @@
+Documentation building: adjusted :mod:`~sphinx.ext.intersphinx` links to remove
+"intersphinx inventory has moved" warnings
+-- by :user:`mr-c`.

--- a/docs/changelog-fragments.d/811.packaging.rst
+++ b/docs/changelog-fragments.d/811.packaging.rst
@@ -1,0 +1,4 @@
+Constrained the version of :pypi:`docutils` to before 0.22 so that the
+:pypi:`sphinx-tabs` plugin continues to work. Can be reverted once
+new release (``> 3.4.7``) of :pypi:`sphinx-tabs` is made
+-- by :user:`mr-c`.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -80,15 +80,12 @@ spelling_word_list_filename = [
 intersphinx_mapping = {
     'python': ('https://docs.python.org/3', None),
     'python2': ('https://docs.python.org/2', None),
-    # Ref: https://github.com/cherrypy/cherrypy/issues/1872
-    'cherrypy': (
-        'https://docs.cherrypy.dev/en/latest',
-        ('https://cherrypy.rtfd.io/en/latest', None),
-    ),
+    'cherrypy': ('https://docs.cherrypy.dev/en/latest', None),
     'trustme': ('https://trustme.readthedocs.io/en/latest/', None),
     'ddt': ('https://ddt.readthedocs.io/en/latest/', None),
     'pyopenssl': ('https://www.pyopenssl.org/en/latest/', None),
-    'towncrier': ('https://towncrier.rtfd.io/en/latest', None),
+    'towncrier': ('https://towncrier.readthedocs.io/en/latest/', None),
+    'sphinx': ('https://www.sphinx-doc.org', None),
 }
 
 linkcheck_ignore = [

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -21,6 +21,7 @@ Fortran
 hardcoded
 hostname
 inclusivity
+intersphinx
 iterable
 linter
 linters


### PR DESCRIPTION
* CherryPy documentation indirection (intersphinx fallback URLs) is no longer needed as of [cherrypy.org domain squatted post Webfaction merging cherrypy#1872](https://github.com/cherrypy/cherrypy/issues/1872).
* Constrained the version of `` :pypi:`docutils` `` to before 0.22 for documentation builds so that the `` :pypi:`sphinx-tabs` `` plugin remains compatible.

❓ **What kind of change does this PR introduce?**

* [ ] 🐞 bug fix
* [ ] 🐣 feature
* [x] 📋 docs update
* [ ] 📋 tests/coverage improvement
* [ ] 📋 refactoring
* [ ] 💥 other

📋 **What is the related issue number (starting with `#`)**

<!-- Are there any issues opened that will be resolved by merging this change? -->
Resolves #<!-- issue number here -->

❓ **What is the current behavior?** (You can also link to an open issue here)
```
intersphinx inventory has moved: https://towncrier.rtfd.io/en/latest/objects.inv -> https://towncrier.readthedocs.io/en/latest/objects.inv
intersphinx inventory has moved: https://cherrypy.rtfd.io/en/latest -> https://docs.cherrypy.dev/en/latest/
```


❓ **What is the new behavior (if this is a feature change)?**
No warnings


📋 **Other information**:



📋 **Contribution checklist:**

(If you're a first-timer, check out
[this guide on making great pull requests][making a lovely PR])

* [x] I wrote descriptive pull request text above
* [x] I think the code is well written
* [x] I wrote [good commit messages]
* [x] I have [squashed related commits together][related squash] after
      the changes have been approved
* [x] Unit tests for the changes exist
* [x] Integration tests for the changes exist (if applicable)
* [x] I used the same coding conventions as the rest of the project
* [x] The new code doesn't generate linter offenses
* [x] Documentation reflects the changes
* [x] The PR relates to *only* one subject with a clear title
      and description in grammatically correct, complete sentences

[good commit messages]: http://chris.beams.io/posts/git-commit/
[making a lovely PR]: https://mtlynch.io/code-review-love/
[related squash]:
https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit
