### PR TITLE
Fix the missing source_url warning raised by jaraco.packaging.sphinx

### DIFF
--- a/docs/changelog-fragments.d/817.packaging.rst
+++ b/docs/changelog-fragments.d/817.packaging.rst
@@ -1,0 +1,4 @@
+Fixed the source code repository URL not being correctly
+exposed in the project metadata.
+
+-- by :user:`julianz-`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,11 +61,11 @@ email = "team@cherrypy.dev"
 
 [project.urls]
 Homepage = "https://cheroot.cherrypy.dev"
+"Source" = "https://github.com/cherrypy/cheroot"
 "Chat: Matrix" = "https://matrix.to/#/#cherrypy-space:matrix.org"
 "CI: GitHub" = "https://github.com/cherrypy/cheroot/actions"
 "Docs: RTD" = "https://cheroot.cherrypy.dev"
 "GitHub: issues" = "https://github.com/cherrypy/cheroot/issues"
-"GitHub: repo" = "https://github.com/cherrypy/cheroot"
 "Tidelift: funding" = "https://tidelift.com/subscription/pkg/pypi-cheroot?utm_source=pypi-cheroot&utm_medium=referral&utm_campaign=pypi"
 
 [project.readme]


### PR DESCRIPTION
Version 10.4.0 of jaraco.packaging.sphinx introduced the requirement to provide a `Source` url. This PR adds it to the urls metadata in `pyproject.toml`. However, because this addition, in effect, duplicates the `GitHub: repo` url that appears in the left sidebar of the PyPI project page, the latter is removed.

❓ **What kind of change does this PR introduce?**

* [x] 🐞 bug fix
* [ ] 🐣 feature
* [ ] 📋 docs update
* [ ] 📋 tests/coverage improvement
* [ ] 📋 refactoring
* [ ] 💥 other

📋 **What is the related issue number (starting with `#`)**

<!-- Are there any issues opened that will be resolved by merging this change? -->
Resolves #<!-- issue number here -->

❓ **What is the current behavior?** (You can also link to an open issue here)
Builds currently fail with a warning:

`The config value 'source_url' has type 'NoneType', defaults to 'str'.` See e.g. [here](https://github.com/cherrypy/cheroot/actions/runs/22498824072/job/65180470516?pr=816)

The jaraco.packaging.sphinx extension added a requirement to provide a source_url as a change in v10.4.0.


❓ **What is the new behavior (if this is a feature change)?**



📋 **Other information**:



📋 **Contribution checklist:**

(If you're a first-timer, check out
[this guide on making great pull requests][making a lovely PR])

* [ ] I wrote descriptive pull request text above
* [ ] I think the code is well written
* [ ] I wrote [good commit messages]
* [ ] I have [squashed related commits together][related squash] after
      the changes have been approved
* [ ] Unit tests for the changes exist
* [ ] Integration tests for the changes exist (if applicable)
* [ ] I used the same coding conventions as the rest of the project
* [ ] The new code doesn't generate linter offenses
* [ ] Documentation reflects the changes
* [ ] The PR relates to *only* one subject with a clear title
      and description in grammatically correct, complete sentences

[good commit messages]: http://chris.beams.io/posts/git-commit/
[making a lovely PR]: https://mtlynch.io/code-review-love/
[related squash]:
https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit
