### PR TITLE
Remove redundant ToC from docs homepage

### DIFF
--- a/docs/changelog-fragments.d/818.doc.rst
+++ b/docs/changelog-fragments.d/818.doc.rst
@@ -1,0 +1,6 @@
+Removed the redundant table of contents from the documentation home page.
+
+Previously the table of contents appeared twice on the :doc:`docs home page
+<index>` -- both in the left hand selection panel and in the main contents next to it.
+
+-- by :user:`julianz-`

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -6,21 +6,25 @@ Welcome to Cheroot documentation!
 .. toctree::
    :maxdepth: 1
    :glob:
+   :hidden:
 
    history
 
 .. toctree::
    :caption: Contributing
+   :hidden:
 
    contributing/guidelines
 
 .. toctree::
    :caption: Maintenance
+   :hidden:
 
    contributing/release_guide
 
 .. toctree::
    :caption: Reference
+   :hidden:
 
    devguide
    Private (dev) API autodoc <pkg/modules>


### PR DESCRIPTION
❓ **What kind of change does this PR introduce?**

* [ ] 🐞 bug fix
* [ ] 🐣 feature
* [x] 📋 docs update
* [ ] 📋 tests/coverage improvement
* [ ] 📋 refactoring
* [ ] 💥 other

📋 **What is the related issue number (starting with `#`)**

<!-- Are there any issues opened that will be resolved by merging this change? -->
Resolves #<!-- issue number here -->

❓ **What is the current behavior?** (You can also link to an open issue here)

Currently the table of contents appears twice on the docs home page `https://cheroot.cherrypy.dev/en/latest/`: both in the left hand selection panel and in the main contents next to it. This commit removes the duplicated content in the main panel.

❓ **What is the new behavior (if this is a feature change)?**



📋 **Other information**:



📋 **Contribution checklist:**

(If you're a first-timer, check out
[this guide on making great pull requests][making a lovely PR])

* [x] I wrote descriptive pull request text above
* [x] I think the code is well written
* [x] I wrote [good commit messages]
* [x] I have [squashed related commits together][related squash] after
      the changes have been approved
* [ ] Unit tests for the changes exist
* [ ] Integration tests for the changes exist (if applicable)
* [ ] I used the same coding conventions as the rest of the project
* [ ] The new code doesn't generate linter offenses
* [ ] Documentation reflects the changes
* [ ] The PR relates to *only* one subject with a clear title
      and description in grammatically correct, complete sentences

[good commit messages]: http://chris.beams.io/posts/git-commit/
[making a lovely PR]: https://mtlynch.io/code-review-love/
[related squash]:
https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit
