### PR TITLE
Prevent socket write buffer from being cleared when prematurely

### DIFF
--- a/cheroot/makefile.py
+++ b/cheroot/makefile.py
@@ -2,11 +2,15 @@
 
 # prefer slower Python-based io module
 import _pyio as io
+import select
 import socket
 
 
 # Write only 16K at a time to sockets
 SOCK_WRITE_BLOCKSIZE = 16384
+
+# Seconds to wait for a blocked socket to become writable
+SOCK_WRITE_TIMEOUT = 10
 
 
 class BufferedWriter(io.BufferedWriter):
@@ -35,8 +39,20 @@ class BufferedWriter(io.BufferedWriter):
                 )
             except io.BlockingIOError as e:
                 n = e.characters_written
-            if n:
-                del self._write_buf[:n]
+            if n is None:
+                _, writable, _ = select.select(
+                    [],
+                    [self.raw],
+                    [],
+                    SOCK_WRITE_TIMEOUT,
+                )
+                if not writable:
+                    raise io.BlockingIOError(
+                        0,
+                        'raw stream blocked; no bytes written',
+                    )
+                continue
+            del self._write_buf[:n]
 
 
 class StreamReader(io.BufferedReader):

--- a/cheroot/makefile.py
+++ b/cheroot/makefile.py
@@ -26,13 +26,17 @@ class BufferedWriter(io.BufferedWriter):
     def _flush_unlocked(self):
         self._checkClosed('flush of closed file')
         while self._write_buf:
+            n = None
             try:
                 # ssl sockets only except 'bytes', not bytearrays
                 # so perhaps we should conditionally wrap this for perf?
-                n = self.raw.write(bytes(self._write_buf))
+                n = self.raw.write(
+                    bytes(self._write_buf[:SOCK_WRITE_BLOCKSIZE]),
+                )
             except io.BlockingIOError as e:
                 n = e.characters_written
-            del self._write_buf[:n]
+            if n:
+                del self._write_buf[:n]
 
 
 class StreamReader(io.BufferedReader):

--- a/cheroot/makefile.pyi
+++ b/cheroot/makefile.pyi
@@ -1,6 +1,7 @@
 import io
 
 SOCK_WRITE_BLOCKSIZE: int
+SOCK_WRITE_TIMEOUT: int
 
 class BufferedWriter(io.BufferedWriter):
     def write(self, b): ...

--- a/cheroot/test/test_makefile.py
+++ b/cheroot/test/test_makefile.py
@@ -53,7 +53,26 @@ def test_bytes_written():
     assert wfile.bytes_written == 3
 
 
-def test_flush_preserves_data_when_raw_write_returns_none():
+class _RawWriteBlockOnce:
+    """Mock raw.write() that returns None on the first call, then writes normally."""
+
+    def __init__(self):
+        """Initialize _RawWriteBlockOnce."""
+        self.call_count = 0
+        self.written = bytearray()
+
+    def __call__(self, chunk):
+        """Return None on first call to simulate a blocked socket write."""
+        self.call_count += 1
+        if self.call_count == 1:
+            return (
+                None  # simulates socket returning None on first blocked write
+            )
+        self.written.extend(chunk)
+        return len(chunk)
+
+
+def test_flush_when_raw_write_returns_none():
     """_flush_unlocked() must not treat None from raw.write() as a byte count.
 
     io.RawIOBase.write() returns None when a non-blocking socket cannot accept
@@ -61,29 +80,17 @@ def test_flush_preserves_data_when_raw_write_returns_none():
     which silently clears the entire buffer, truncating the response without
     raising an exception.
     """
-    data = b'x' * 32768  # larger than SOCK_WRITE_BLOCKSIZE to stress the loop
+    data = b'x' * (makefile.SOCK_WRITE_BLOCKSIZE * 2)  # stress the write loop
 
     sock = MockSocket()
     wfile = makefile.MakeFile(sock, 'w')
     wfile._write_buf.extend(data)
 
-    written = bytearray()
-    call_count = 0
-
-    def mock_raw_write(b):
-        nonlocal call_count
-        call_count += 1
-        if call_count == 1:
-            return (
-                None  # simulates socket returning None on first blocked write
-            )
-        written.extend(b)
-        return len(b)
-
-    wfile.raw.write = mock_raw_write
+    mock = _RawWriteBlockOnce()
+    wfile.raw.write = mock
     wfile._flush_unlocked()
 
-    assert bytes(written) == data, (
-        f'Expected {len(data)} bytes but only {len(written)} reached raw.write(): '
+    assert bytes(mock.written) == data, (
+        f'Expected {len(data)} bytes but only {len(mock.written)} reached raw.write(): '
         'buffer was silently discarded when raw.write() returned None'
     )

--- a/cheroot/test/test_makefile.py
+++ b/cheroot/test/test_makefile.py
@@ -51,3 +51,39 @@ def test_bytes_written():
     wfile = makefile.MakeFile(sock, 'w')
     wfile.write(b'bar')
     assert wfile.bytes_written == 3
+
+
+def test_flush_preserves_data_when_raw_write_returns_none():
+    """_flush_unlocked() must not treat None from raw.write() as a byte count.
+
+    io.RawIOBase.write() returns None when a non-blocking socket cannot accept
+    data. del self._write_buf[:None] is equivalent to del self._write_buf[:]
+    which silently clears the entire buffer, truncating the response without
+    raising an exception.
+    """
+    data = b'x' * 32768  # larger than SOCK_WRITE_BLOCKSIZE to stress the loop
+
+    sock = MockSocket()
+    wfile = makefile.MakeFile(sock, 'w')
+    wfile._write_buf.extend(data)
+
+    written = bytearray()
+    call_count = 0
+
+    def mock_raw_write(b):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            return (
+                None  # simulates socket returning None on first blocked write
+            )
+        written.extend(b)
+        return len(b)
+
+    wfile.raw.write = mock_raw_write
+    wfile._flush_unlocked()
+
+    assert bytes(written) == data, (
+        f'Expected {len(data)} bytes but only {len(written)} reached raw.write(): '
+        'buffer was silently discarded when raw.write() returned None'
+    )

--- a/cheroot/test/test_makefile.py
+++ b/cheroot/test/test_makefile.py
@@ -54,7 +54,7 @@ def test_bytes_written():
 
 
 class _RawWriteBlockOnce:
-    """Mock raw.write() that returns None on the first call, then writes normally."""
+    """Mock raw.write() returning None once, then writing normally."""
 
     def __init__(self):
         """Initialize _RawWriteBlockOnce."""
@@ -62,25 +62,41 @@ class _RawWriteBlockOnce:
         self.written = bytearray()
 
     def __call__(self, chunk):
-        """Return None on first call to simulate a blocked socket write."""
+        """Return None on first call to simulate a blocked write."""
         self.call_count += 1
         if self.call_count == 1:
-            return (
-                None  # simulates socket returning None on first blocked write
-            )
+            return None
         self.written.extend(chunk)
         return len(chunk)
 
+    def fileno(self):
+        """Return a fake fd for select()."""
+        return -1
 
-def test_flush_when_raw_write_returns_none():
-    """_flush_unlocked() must not treat None from raw.write() as a byte count.
 
-    io.RawIOBase.write() returns None when a non-blocking socket cannot accept
-    data. del self._write_buf[:None] is equivalent to del self._write_buf[:]
-    which silently clears the entire buffer, truncating the response without
-    raising an exception.
+class _RawWriteBlockAlways:
+    """Mock raw.write() that always returns None."""
+
+    def __init__(self):
+        """Initialize _RawWriteBlockAlways."""
+        self.call_count = 0
+
+    def __call__(self, chunk):
+        """Return None to simulate a permanently blocked socket."""
+        self.call_count += 1
+
+    def fileno(self):
+        """Return a fake fd for select()."""
+        return -1
+
+
+def test_flush_recovers_from_temporary_block(monkeypatch):
+    """_flush_unlocked() retries after select when raw.write() returns None.
+
+    A temporarily blocked socket should recover once select() reports
+    the socket is writable again, delivering all buffered data.
     """
-    data = b'x' * (makefile.SOCK_WRITE_BLOCKSIZE * 2)  # stress the write loop
+    data = b'x' * (makefile.SOCK_WRITE_BLOCKSIZE * 2)
 
     sock = MockSocket()
     wfile = makefile.MakeFile(sock, 'w')
@@ -88,9 +104,47 @@ def test_flush_when_raw_write_returns_none():
 
     mock = _RawWriteBlockOnce()
     wfile.raw.write = mock
+
+    # select() reports writable immediately
+    monkeypatch.setattr(
+        'cheroot.makefile.select.select',
+        lambda _rlist, wlist, _xlist, _timeout: ([], wlist, []),
+    )
     wfile._flush_unlocked()
 
     assert bytes(mock.written) == data, (
-        f'Expected {len(data)} bytes but only {len(mock.written)} reached raw.write(): '
-        'buffer was silently discarded when raw.write() returned None'
+        'all buffered data should be written after select retry'
+    )
+
+
+def test_flush_raises_on_sustained_block(monkeypatch):
+    """_flush_unlocked() raises BlockingIOError after select timeout.
+
+    If the socket stays blocked past SOCK_WRITE_TIMEOUT, the write
+    buffer must be preserved and BlockingIOError raised.
+    """
+    import io
+
+    import pytest
+
+    data = b'x' * makefile.SOCK_WRITE_BLOCKSIZE
+
+    sock = MockSocket()
+    wfile = makefile.MakeFile(sock, 'w')
+    wfile._write_buf.extend(data)
+
+    mock = _RawWriteBlockAlways()
+    wfile.raw.write = mock
+
+    # select() reports not writable (timeout)
+    monkeypatch.setattr(
+        'cheroot.makefile.select.select',
+        lambda _rlist, _wlist, _xlist, _timeout: ([], [], []),
+    )
+
+    with pytest.raises(io.BlockingIOError):
+        wfile._flush_unlocked()
+
+    assert len(wfile._write_buf) == len(data), (
+        'write buffer must be preserved when socket stays blocked'
     )

--- a/docs/changelog-fragments.d/822.bugfix.rst
+++ b/docs/changelog-fragments.d/822.bugfix.rst
@@ -1,0 +1,3 @@
+Fixed a bug that could cause premature clearing of the write buffer when a socket write is blocked.
+
+-- by :user:`cbbm142`

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -5,6 +5,7 @@ backports
 bugfixes
 builtin
 b'xb
+buf
 compat
 config
 conftest
@@ -22,6 +23,7 @@ hardcoded
 hostname
 inclusivity
 intersphinx
+io
 iterable
 linter
 linters
@@ -48,6 +50,7 @@ preconfigure
 py
 pytest
 pythonic
+RawIOBase
 readonly
 rebase
 Refactor


### PR DESCRIPTION
Adds a check in cheroot.makefile.BufferedWriter._flush_unlocked to prevent clearing of the write buffer when raw.write() returns None due to a blocked stream. Also limits each write call to SOCK_WRITE_BLOCKSIZE bytes, which was defined but not previously used in this method.

❓ **What kind of change does this PR introduce?**
Prevent socket write buffer from being cleared when it is blocked
* [x] 🐞 bug fix
* [ ] 🐣 feature
* [ ] 📋 docs update
* [ ] 📋 tests/coverage improvement
* [ ] 📋 refactoring
* [ ] 💥 other

📋 **What is the related issue number (starting with `#`)**

Resolves #821 

❓ **What is the current behavior?** (You can also link to an open issue here)

https://github.com/cherrypy/cheroot/issues/821

❓ **What is the new behavior (if this is a feature change)?**

N/A

📋 **Other information**:

This bug is hard to reproduce and spot in production since there are no tracebacks or log messages associated with it.  It happens because n can be None, and then `del self._write_buf[:n]` becomes `del self._write_buf[:]` which will clear everything left in the buffer.

📋 **Contribution checklist:**

(If you're a first-timer, check out
[this guide on making great pull requests][making a lovely PR])

* [x] I wrote descriptive pull request text above
* [x] I think the code is well written
* [x] I wrote [good commit messages]
* [ ] I have [squashed related commits together][related squash] after
      the changes have been approved
* [x] Unit tests for the changes exist
* [ ] Integration tests for the changes exist (if applicable)
* [x] I used the same coding conventions as the rest of the project
* [x] The new code doesn't generate linter offenses
* [ ] Documentation reflects the changes
* [x] The PR relates to *only* one subject with a clear title
      and description in grammatically correct, complete sentences

[good commit messages]: http://chris.beams.io/posts/git-commit/
[making a lovely PR]: https://mtlynch.io/code-review-love/
[related squash]:
https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit
