### PR TITLE
Bump Ruff to v0.15.18 and address new lint violations

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -60,7 +60,7 @@ repos:
   - id: no_optional
 
 - repo: https://github.com/astral-sh/ruff-pre-commit.git
-  rev: v0.13.3
+  rev: v0.15.18
   hooks:
   - id: ruff
     args:
@@ -68,7 +68,7 @@ repos:
     - --fix  # NOTE: When `--fix` is used, linting should be before ruff-format
 
 - repo: https://github.com/astral-sh/ruff-pre-commit.git
-  rev: v0.13.3
+  rev: v0.15.18
   hooks:
   - id: ruff-format
     alias: ruff-format-first-pass
@@ -80,7 +80,7 @@ repos:
   - id: add-trailing-comma
 
 - repo: https://github.com/astral-sh/ruff-pre-commit.git
-  rev: v0.13.3
+  rev: v0.15.18
   hooks:
   - id: ruff-format
     alias: ruff-format-second-pass

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -101,6 +101,7 @@ ignore = [
   "PLR6104",  # non-augmented-assignment  # FIXME
   "PLR6301",  # no-self-use  # FIXME / noqa
 
+  "PLW0717",  # too-many-statements-in-try-clause  # FIXME
   "PLW1514",  # unspecified-encoding  # FIXME
 
   "PTH100",  # os-path-abspath  # FIXME
@@ -115,6 +116,7 @@ ignore = [
   "PYI024",  # collections-named-tuple  # FIXME
 
   "RUF005",  # collection-literal-concatenation  # FIXME
+  "RUF067",  # non-empty-init-module  # FIXME
   "RUF012",  # mutable-class-default  # FIXME
   "RUF043",  # pytest-raises-ambiguous-pattern  # FIXME
   "RUF048",  # map-int-version-parsing  # FIXME
@@ -215,6 +217,7 @@ testing = [
   "S101",  # Allow use of `assert` in test files
   "S404",  # Allow importing 'subprocess' module to testing call external tools needed by these hooks
   "S603",  # subprocess-without-shell-equals-true
+  "S607",  # start-process-with-partial-path  # FIXME
   "SLF001",  # Private member accessed
 ]
 

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -219,7 +219,6 @@ testing = [
   "ARG004",  # unused-static-method-argument (hit in WSGI test apps)
   "PLC2701",  # Allow importing internal files needed for testing
   # "PLR6301",  # Allow 'self' parameter in method definitions (required for test stubs)
-  "PLW0717",  # too-many-statements-in-try-clause  # FIXME
   "S101",  # Allow use of `assert` in test files
   "S404",  # Allow importing 'subprocess' module to testing call external tools needed by these hooks
   "S603",  # subprocess-without-shell-equals-true

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -101,7 +101,6 @@ ignore = [
   "PLR6104",  # non-augmented-assignment  # FIXME
   "PLR6301",  # no-self-use  # FIXME / noqa
 
-  "PLW0717",  # too-many-statements-in-try-clause  # FIXME
   "PLW1514",  # unspecified-encoding  # FIXME
 
   "PTH100",  # os-path-abspath  # FIXME
@@ -208,12 +207,19 @@ testing = [
 
 
 [lint.per-file-ignores]
+# Too many statements in try clause — FIXME: narrow these try blocks
+"cheroot/connections.py" = ["PLW0717"]
+"cheroot/server.py" = ["PLW0717"]
+"cheroot/ssl/pyopenssl.py" = ["PLW0717"]
+"cheroot/wsgi.py" = ["PLW0717"]
+
 # Exceptions for test files
 "cheroot/test/**.py" = [
   "ARG002",  # Allow unused arguments in instance methods (required for test stubs)
   "ARG004",  # unused-static-method-argument (hit in WSGI test apps)
   "PLC2701",  # Allow importing internal files needed for testing
   # "PLR6301",  # Allow 'self' parameter in method definitions (required for test stubs)
+  "PLW0717",  # too-many-statements-in-try-clause  # FIXME
   "S101",  # Allow use of `assert` in test files
   "S404",  # Allow importing 'subprocess' module to testing call external tools needed by these hooks
   "S603",  # subprocess-without-shell-equals-true

--- a/cheroot/connections.py
+++ b/cheroot/connections.py
@@ -80,7 +80,7 @@ class _ThreadsafeSelector:
 
     @property
     def connections(self):
-        """Retrieve connections registered with the selector."""
+        """Connections registered with the selector."""
         with self._lock:
             mapping = self._selector.get_map() or {}
             for _, (_, sock_fd, _, conn) in mapping.items():
@@ -386,7 +386,7 @@ class ConnectionManager:
 
     @property
     def _num_connections(self):
-        """Return the current number of connections.
+        """The current number of connections.
 
         Includes all connections registered with the selector,
         minus one for the server socket, which is always registered

--- a/cheroot/server.py
+++ b/cheroot/server.py
@@ -1453,19 +1453,19 @@ class HTTPConnection:
 
     @property
     def peer_pid(self):
-        """Return the id of the connected peer process."""
+        """The id of the connected peer process."""
         pid, _, _ = self.get_peer_creds()
         return pid
 
     @property
     def peer_uid(self):
-        """Return the user id of the connected peer process."""
+        """The user id of the connected peer process."""
         _, uid, _ = self.get_peer_creds()
         return uid
 
     @property
     def peer_gid(self):
-        """Return the group id of the connected peer process."""
+        """The group id of the connected peer process."""
         _, _, gid = self.get_peer_creds()
         return gid
 
@@ -1495,13 +1495,13 @@ class HTTPConnection:
 
     @property
     def peer_user(self):
-        """Return the username of the connected peer process."""
+        """The username of the connected peer process."""
         user, _ = self.resolve_peer_creds()
         return user
 
     @property
     def peer_group(self):
-        """Return the group of the connected peer process."""
+        """The group of the connected peer process."""
         _, group = self.resolve_peer_creds()
         return group
 
@@ -1750,7 +1750,7 @@ class HTTPServer:
 
     @property
     def bind_addr(self):
-        """Return the interface on which to listen for connections.
+        """The interface on which to listen for connections.
 
         For TCP sockets, a (host, port) tuple. Host values may be any
         :term:`IPv4` or :term:`IPv6` address, or any valid hostname.
@@ -2234,7 +2234,7 @@ class HTTPServer:
 
     @property
     def _stopping_for_interrupt(self):
-        """Return whether the server is responding to an interrupt."""
+        """Whether the server is responding to an interrupt."""
         return self._interrupt is _STOPPING_FOR_INTERRUPT
 
     @interrupt.setter

--- a/cheroot/test/_pytest_plugin.py
+++ b/cheroot/test/_pytest_plugin.py
@@ -21,25 +21,37 @@ def pytest_load_initial_conftests(early_config, parser, args):
     # * https://github.com/pytest-dev/pytest/issues/5299
     early_config._inicache['filterwarnings'].extend(
         (
-            'ignore:Exception in thread CP Server Thread-:'
-            'pytest.PytestUnhandledThreadExceptionWarning:_pytest.threadexception',
-            'ignore:Exception in thread Thread-:'
-            'pytest.PytestUnhandledThreadExceptionWarning:_pytest.threadexception',
-            'ignore:Exception ignored in. '
-            '<socket.socket fd=-1, family=AddressFamily.AF_INET, '
-            'type=SocketKind.SOCK_STREAM, proto=.:'
-            'pytest.PytestUnraisableExceptionWarning:_pytest.unraisableexception',
-            'ignore:Exception ignored in. '
-            '<socket.socket fd=-1, family=AddressFamily.AF_INET6, '
-            'type=SocketKind.SOCK_STREAM, proto=.:'
-            'pytest.PytestUnraisableExceptionWarning:_pytest.unraisableexception',
-            'ignore:Exception ignored in. '
-            '<socket.socket fd=-1, family=AF_INET, '
-            'type=SocketKind.SOCK_STREAM, proto=.:'
-            'pytest.PytestUnraisableExceptionWarning:_pytest.unraisableexception',
-            'ignore:Exception ignored in. '
-            '<socket.socket fd=-1, family=AF_INET6, '
-            'type=SocketKind.SOCK_STREAM, proto=.:'
-            'pytest.PytestUnraisableExceptionWarning:_pytest.unraisableexception',
+            (
+                'ignore:Exception in thread CP Server Thread-:'
+                'pytest.PytestUnhandledThreadExceptionWarning:_pytest.threadexception'
+            ),
+            (
+                'ignore:Exception in thread Thread-:'
+                'pytest.PytestUnhandledThreadExceptionWarning:_pytest.threadexception'
+            ),
+            (
+                'ignore:Exception ignored in. '
+                '<socket.socket fd=-1, family=AddressFamily.AF_INET, '
+                'type=SocketKind.SOCK_STREAM, proto=.:'
+                'pytest.PytestUnraisableExceptionWarning:_pytest.unraisableexception'
+            ),
+            (
+                'ignore:Exception ignored in. '
+                '<socket.socket fd=-1, family=AddressFamily.AF_INET6, '
+                'type=SocketKind.SOCK_STREAM, proto=.:'
+                'pytest.PytestUnraisableExceptionWarning:_pytest.unraisableexception'
+            ),
+            (
+                'ignore:Exception ignored in. '
+                '<socket.socket fd=-1, family=AF_INET, '
+                'type=SocketKind.SOCK_STREAM, proto=.:'
+                'pytest.PytestUnraisableExceptionWarning:_pytest.unraisableexception'
+            ),
+            (
+                'ignore:Exception ignored in. '
+                '<socket.socket fd=-1, family=AF_INET6, '
+                'type=SocketKind.SOCK_STREAM, proto=.:'
+                'pytest.PytestUnraisableExceptionWarning:_pytest.unraisableexception'
+            ),
         ),
     )

--- a/cheroot/test/test_conn.py
+++ b/cheroot/test/test_conn.py
@@ -191,9 +191,7 @@ def testing_server(raw_testing_server, monkeypatch):
             continue
 
         assert c_msg in raw_testing_server.error_log.ignored_msgs, (
-            'Found error in the error log: '
-            f"message = '{c_msg}', level = '{c_level}'\n"
-            f'{c_traceback}',
+            f"Found error in the error log: message = '{c_msg}', level = '{c_level}'\n{c_traceback}"  # noqa: LN001
         )
 
 
@@ -790,17 +788,11 @@ def test_broken_connection_during_http_communication_fallback(  # noqa: WPS118
         (logging.WARNING, r'^socket\.error 666$'),
         (
             logging.INFO,
-            '^Got a connection error while handling a connection '
-            r'from .*:\d{1,5} \(666\)',
+            r'^Got a connection error while handling a connection from .*:\d{1,5} \(666\)',  # noqa: LN001
         ),
         (
             logging.CRITICAL,
-            r'A fatal exception happened\. Setting the server interrupt flag '
-            r'to ConnectionResetError\(666,?\) and giving up\.\n\nPlease, '
-            'report this on the Cheroot tracker at '
-            r'<https://github\.com/cherrypy/cheroot/issues/new/choose>, '
-            'providing a full reproducer with as much context and details '
-            r'as possible\.$',
+            r'A fatal exception happened\. Setting the server interrupt flag to ConnectionResetError\(666,?\) and giving up\.\n\nPlease, report this on the Cheroot tracker at <https://github\.com/cherrypy/cheroot/issues/new/choose>, providing a full reproducer with as much context and details as possible\.$',  # noqa: LN001
         ),
     )
 
@@ -840,13 +832,11 @@ def test_kb_int_from_http_handler(
     expected_log_entries = (
         (
             logging.DEBUG,
-            '^Got a server shutdown request while handling a connection '
-            r'from .*:\d{1,5} \(simulated test handler keyboard interrupt\)$',
+            r'^Got a server shutdown request while handling a connection from .*:\d{1,5} \(simulated test handler keyboard interrupt\)$',  # noqa: LN001
         ),
         (
             logging.DEBUG,
-            '^Setting the server interrupt flag to KeyboardInterrupt'
-            r"\('simulated test handler keyboard interrupt',?\)$",
+            r"^Setting the server interrupt flag to KeyboardInterrupt\('simulated test handler keyboard interrupt',?\)$",  # noqa: LN001
         ),
         (
             logging.INFO,
@@ -913,9 +903,7 @@ def test_unhandled_exception_in_request_handler(
     expected_log_entries = (
         (
             logging.ERROR,
-            '^Unhandled error while processing an incoming connection '
-            'SillyMistake'
-            r"\('simulated unhandled exception 💣 in test handler',?\)$",
+            r"^Unhandled error while processing an incoming connection SillyMistake\('simulated unhandled exception 💣 in test handler',?\)$",  # noqa: LN001
         ),
         (
             logging.INFO,
@@ -997,8 +985,7 @@ def test_remains_alive_post_unhandled_exception(
     expected_log_entries = (
         (
             logging.ERROR,
-            '^Unhandled error while processing an incoming connection '
-            r'ScaryCrash\(666,?\)$',
+            r'^Unhandled error while processing an incoming connection ScaryCrash\(666,?\)$',  # noqa: LN001
         ),
         (
             logging.INFO,

--- a/cheroot/test/test_conn.py
+++ b/cheroot/test/test_conn.py
@@ -191,7 +191,8 @@ def testing_server(raw_testing_server, monkeypatch):
             continue
 
         assert c_msg in raw_testing_server.error_log.ignored_msgs, (
-            f"Found error in the error log: message = '{c_msg}', level = '{c_level}'\n{c_traceback}"  # noqa: LN001
+            f"Found error in the error log: message = '{c_msg}', "
+            f"level = '{c_level}'\n{c_traceback}"
         )
 
 
@@ -788,11 +789,21 @@ def test_broken_connection_during_http_communication_fallback(  # noqa: WPS118
         (logging.WARNING, r'^socket\.error 666$'),
         (
             logging.INFO,
-            r'^Got a connection error while handling a connection from .*:\d{1,5} \(666\)',  # noqa: LN001
+            (
+                r'^Got a connection error while handling a connection '
+                r'from .*:\d{1,5} \(666\)'
+            ),
         ),
         (
             logging.CRITICAL,
-            r'A fatal exception happened\. Setting the server interrupt flag to ConnectionResetError\(666,?\) and giving up\.\n\nPlease, report this on the Cheroot tracker at <https://github\.com/cherrypy/cheroot/issues/new/choose>, providing a full reproducer with as much context and details as possible\.$',  # noqa: LN001
+            (
+                r'A fatal exception happened\. Setting the server interrupt flag '
+                r'to ConnectionResetError\(666,?\) and giving up\.\n\nPlease, '
+                r'report this on the Cheroot tracker at '
+                r'<https://github\.com/cherrypy/cheroot/issues/new/choose>, '
+                r'providing a full reproducer with as much context and details '
+                r'as possible\.$'
+            ),
         ),
     )
 
@@ -832,11 +843,17 @@ def test_kb_int_from_http_handler(
     expected_log_entries = (
         (
             logging.DEBUG,
-            r'^Got a server shutdown request while handling a connection from .*:\d{1,5} \(simulated test handler keyboard interrupt\)$',  # noqa: LN001
+            (
+                r'^Got a server shutdown request while handling a connection '
+                r'from .*:\d{1,5} \(simulated test handler keyboard interrupt\)$'
+            ),
         ),
         (
             logging.DEBUG,
-            r"^Setting the server interrupt flag to KeyboardInterrupt\('simulated test handler keyboard interrupt',?\)$",  # noqa: LN001
+            (
+                r'^Setting the server interrupt flag to KeyboardInterrupt'
+                r"\('simulated test handler keyboard interrupt',?\)$"
+            ),
         ),
         (
             logging.INFO,
@@ -903,7 +920,10 @@ def test_unhandled_exception_in_request_handler(
     expected_log_entries = (
         (
             logging.ERROR,
-            r"^Unhandled error while processing an incoming connection SillyMistake\('simulated unhandled exception 💣 in test handler',?\)$",  # noqa: LN001
+            (
+                r'^Unhandled error while processing an incoming connection '
+                r"SillyMistake\('simulated unhandled exception 💣 in test handler',?\)$"
+            ),
         ),
         (
             logging.INFO,
@@ -985,7 +1005,10 @@ def test_remains_alive_post_unhandled_exception(
     expected_log_entries = (
         (
             logging.ERROR,
-            r'^Unhandled error while processing an incoming connection ScaryCrash\(666,?\)$',  # noqa: LN001
+            (
+                r'^Unhandled error while processing an incoming connection '
+                r'ScaryCrash\(666,?\)$'
+            ),
         ),
         (
             logging.INFO,

--- a/cheroot/test/test_ssl.py
+++ b/cheroot/test/test_ssl.py
@@ -480,51 +480,75 @@ def test_tls_client_auth(  # noqa: C901, WPS213  # FIXME
             expected_substrings += (
                 (
                     "bad handshake: SysCallError(10054, 'WSAECONNRESET')",
-                    "('Connection aborted.', "
-                    'OSError("(10054, \'WSAECONNRESET\')"))',
-                    "('Connection aborted.', "
-                    'OSError("(10054, \'WSAECONNRESET\')",))',
-                    "('Connection aborted.', "
-                    'error("(10054, \'WSAECONNRESET\')",))',
-                    "('Connection aborted.', "
-                    'ConnectionResetError(10054, '
-                    "'An existing connection was forcibly closed "
-                    "by the remote host', None, 10054, None))",
-                    "('Connection aborted.', "
-                    'error(10054, '
-                    "'An existing connection was forcibly closed "
-                    "by the remote host'))",
+                    (
+                        "('Connection aborted.', "
+                        'OSError("(10054, \'WSAECONNRESET\')"))'
+                    ),
+                    (
+                        "('Connection aborted.', "
+                        'OSError("(10054, \'WSAECONNRESET\')",))'
+                    ),
+                    (
+                        "('Connection aborted.', "
+                        'error("(10054, \'WSAECONNRESET\')",))'
+                    ),
+                    (
+                        "('Connection aborted.', "
+                        'ConnectionResetError(10054, '
+                        "'An existing connection was forcibly closed "
+                        "by the remote host', None, 10054, None))"
+                    ),
+                    (
+                        "('Connection aborted.', "
+                        'error(10054, '
+                        "'An existing connection was forcibly closed "
+                        "by the remote host'))"
+                    ),
                 )
                 if IS_WINDOWS
                 else (
-                    "('Connection aborted.', "
-                    'OSError("(104, \'ECONNRESET\')"))',
-                    "('Connection aborted.', "
-                    'OSError("(104, \'ECONNRESET\')",))',
+                    (
+                        "('Connection aborted.', "
+                        'OSError("(104, \'ECONNRESET\')"))'
+                    ),
+                    (
+                        "('Connection aborted.', "
+                        'OSError("(104, \'ECONNRESET\')",))'
+                    ),
                     "('Connection aborted.', error(\"(104, 'ECONNRESET')\",))",
-                    "('Connection aborted.', "
-                    "ConnectionResetError(104, 'Connection reset by peer'))",
-                    "('Connection aborted.', "
-                    "error(104, 'Connection reset by peer'))",
+                    (
+                        "('Connection aborted.', "
+                        "ConnectionResetError(104, 'Connection reset by peer'))"
+                    ),
+                    (
+                        "('Connection aborted.', "
+                        "error(104, 'Connection reset by peer'))"
+                    ),
                 )
                 if (IS_GITHUB_ACTIONS_WORKFLOW and IS_LINUX)
                 else (
-                    "('Connection aborted.', "
-                    "BrokenPipeError(32, 'Broken pipe'))",
+                    (
+                        "('Connection aborted.', "
+                        "BrokenPipeError(32, 'Broken pipe'))"
+                    ),
                 )
             )
 
         if PY310_PLUS:
             # FIXME: Figure out what's happening and correct the problem
             expected_substrings += (
-                'SSLError(SSLEOFError(8, '
-                "'EOF occurred in violation of protocol (_ssl.c:",
+                (
+                    'SSLError(SSLEOFError(8, '
+                    "'EOF occurred in violation of protocol (_ssl.c:"
+                ),
             )
         if IS_GITHUB_ACTIONS_WORKFLOW and IS_WINDOWS and PY310_PLUS:
             expected_substrings += (
-                "('Connection aborted.', "
-                'RemoteDisconnected('
-                "'Remote end closed connection without response'))",
+                (
+                    "('Connection aborted.', "
+                    'RemoteDisconnected('
+                    "'Remote end closed connection without response'))"
+                ),
             )
 
         assert any(e in err_text for e in expected_substrings)
@@ -662,8 +686,10 @@ def test_ssl_env(  # noqa: C901  # FIXME
             pytest.xfail(
                 '\n'.join(
                     (
-                        'Sometimes this test fails due to '
-                        'a socket.socket ResourceWarning:',
+                        (
+                            'Sometimes this test fails due to '
+                            'a socket.socket ResourceWarning:'
+                        ),
                         msg,
                     ),
                 ),

--- a/cheroot/test/webtest.py
+++ b/cheroot/test/webtest.py
@@ -120,7 +120,7 @@ class WebCase(unittest.TestCase):
 
     @property
     def _Conn(self):
-        """Return HTTPConnection or HTTPSConnection based on self.scheme.
+        """HTTPConnection or HTTPSConnection based on self.scheme.
 
         * from :py:mod:`python:http.client`.
         """
@@ -305,7 +305,7 @@ class WebCase(unittest.TestCase):
             sys.stdout.flush()
 
     @property
-    def status_code(self):  # noqa: D401; irrelevant for properties
+    def status_code(self):
         """Integer HTTP status code."""
         return int(self.status[:3])
 

--- a/cheroot/workers/threadpool.py
+++ b/cheroot/workers/threadpool.py
@@ -299,8 +299,8 @@ class ThreadPool:
         self.grow(self.min)
 
     @property
-    def idle(self):  # noqa: D401; irrelevant for properties
-        """Number of worker threads which are idle. Read-only."""  # noqa: D401
+    def idle(self):
+        """Number of worker threads which are idle. Read-only."""
         idles = len([t for t in self._threads if t.conn is None])
         return max(idles - len(self._pending_shutdowns), 0)
 
@@ -432,5 +432,5 @@ class ThreadPool:
 
     @property
     def qsize(self):
-        """Return the queue size."""
+        """The queue size."""
         return self._queue.qsize()

--- a/docs/changelog-fragments.d/826.contrib.rst
+++ b/docs/changelog-fragments.d/826.contrib.rst
@@ -1,0 +1,12 @@
+Bumped Ruff to v0.15.18, which introduces new rules:
+
+1. Property docstrings must now use noun phrases rather than verb phrases
+   (D421, e.g. "The queue size." not "Return the queue size."),
+2. Implicit string concatenation inside collection literals must be
+   parenthesized (ISC004).
+
+Three further new rules are suppressed pending fixes: too many statements
+in a try clause (PLW0717), non-empty ``__init__`` modules (RUF067), and
+starting a process with a partial executable path (S607)
+
+-- by :user:`julianz-`.

--- a/docs/changelog-fragments.d/826.contrib.rst
+++ b/docs/changelog-fragments.d/826.contrib.rst
@@ -7,6 +7,6 @@ Bumped Ruff to v0.15.18, which introduces new rules:
 
 Three further new rules are suppressed pending fixes: too many statements
 in a try clause (PLW0717), non-empty ``__init__`` modules (RUF067), and
-starting a process with a partial executable path (S607)
+starting a process with a partial executable path (S607).
 
--- by :user:`julianz-`.
+-- by :user:`julianz-`

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -107,10 +107,8 @@ linkcheck_ignore = [
     r'https://github\.com/cherrypy/cherrypy/tree',
     # Has an ephemeral anchor (line-range) but actual HTML has separate per-
     # line anchors.
-    r'https://github\.com'
-    r'/python/cpython/blob/c39b52f/Lib/poplib\.py#L297-L302',
-    r'https://github\.com'
-    r'/python/cpython/blob/c39b52f/Lib/poplib\.py#user-content-L297-L302',
+    r'https://github\.com/python/cpython/blob/c39b52f/Lib/poplib\.py#L297-L302',  # noqa: LN001
+    r'https://github\.com/python/cpython/blob/c39b52f/Lib/poplib\.py#user-content-L297-L302',  # noqa: LN001
     r'^https://img\.shields\.io/matrix',  # these are rate-limited
     r'^https://matrix\.to/#',  # these render fully on front-end from anchors
     r'^https://stackoverflow\.com/',  # these generate HTTP 403 Forbidden

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -107,8 +107,14 @@ linkcheck_ignore = [
     r'https://github\.com/cherrypy/cherrypy/tree',
     # Has an ephemeral anchor (line-range) but actual HTML has separate per-
     # line anchors.
-    r'https://github\.com/python/cpython/blob/c39b52f/Lib/poplib\.py#L297-L302',  # noqa: LN001
-    r'https://github\.com/python/cpython/blob/c39b52f/Lib/poplib\.py#user-content-L297-L302',  # noqa: LN001
+    (
+        r'https://github\.com'
+        r'/python/cpython/blob/c39b52f/Lib/poplib\.py#L297-L302'
+    ),
+    (
+        r'https://github\.com'
+        r'/python/cpython/blob/c39b52f/Lib/poplib\.py#user-content-L297-L302'
+    ),
     r'^https://img\.shields\.io/matrix',  # these are rate-limited
     r'^https://matrix\.to/#',  # these render fully on front-end from anchors
     r'^https://stackoverflow\.com/',  # these generate HTTP 403 Forbidden


### PR DESCRIPTION
Updates Ruff from v0.13.3 to v0.15.18
This requires the following changes:
- Fix D421: reword property docstrings to noun phrases
- Fix ISC004: parenthesize implicit string concatenation in collections; use single strings with # noqa: LN001 where readability is better
- Drop now-redundant # noqa: D401 comments on property definitions
- Suppress PLW0717, RUF067, S607 pending future fixes

❓ **What kind of change does this PR introduce?**

* [ ] 🐞 bug fix
* [ ] 🐣 feature
* [ ] 📋 docs update
* [ ] 📋 tests/coverage improvement
* [ ] 📋 refactoring
* [x] 💥 other

📋 **What is the related issue number (starting with `#`)**

<!-- Are there any issues opened that will be resolved by merging this change? -->
Resolves #<!-- issue number here -->

❓ **What is the current behavior?** (You can also link to an open issue here)



❓ **What is the new behavior (if this is a feature change)?**



📋 **Other information**:



📋 **Contribution checklist:**

(If you're a first-timer, check out
[this guide on making great pull requests][making a lovely PR])

* [x] I wrote descriptive pull request text above
* [x] I think the code is well written
* [x] I wrote [good commit messages]
* [ ] I have [squashed related commits together][related squash] after
      the changes have been approved
* [ ] Unit tests for the changes exist
* [ ] Integration tests for the changes exist (if applicable)
* [x] I used the same coding conventions as the rest of the project
* [x] The new code doesn't generate linter offenses
* [x] Documentation reflects the changes
* [x] The PR relates to *only* one subject with a clear title
      and description in grammatically correct, complete sentences
