### PR TITLE
Fix test_https_over_http_error on Windows with OpenSSL 3.1+

### DIFF
--- a/cheroot/test/test_ssl.py
+++ b/cheroot/test/test_ssl.py
@@ -527,7 +527,9 @@ def test_tls_client_auth(  # noqa: C901, WPS213  # FIXME
                 "'Remote end closed connection without response'))",
             )
 
-        assert any(e in err_text for e in expected_substrings)
+        assert any(e in err_text for e in expected_substrings), (
+            f'Unexpected error text: {err_text!r}'
+        )
 
 
 @pytest.mark.parametrize(  # noqa: C901  # FIXME
@@ -697,14 +699,26 @@ def test_https_over_http_error(http_server, ip_addr):
         http.client.HTTPSConnection(
             f'{interface}:{port}',
         ).request('GET', '/')
-    expected_substring = (
-        'record layer failure'
-        if IS_ABOVE_OPENSSL31
-        else 'wrong version number'
-        if IS_ABOVE_OPENSSL10
-        else 'unknown protocol'
-    )
-    assert expected_substring in ssl_err.value.args[-1]
+    underlying_error_string = str(ssl_err.value)
+    if IS_ABOVE_OPENSSL31 and IS_WINDOWS:
+        # On Windows, the TCP reset (RST) is surfaced before OpenSSL processes
+        # the server's response, yielding 'wrong version number' rather than
+        # the usual 'record layer failure'. See CPython's own test_ssl.py:
+        # https://github.com/python/cpython/blob/\
+        # 1b9fe5c7226eccc8b269a7443148033080399f43\
+        # /Lib/test/test_ssl.py#L5705
+        assert 'wrong version number' in underlying_error_string
+    elif IS_ABOVE_OPENSSL31:
+        # Newer Python returns 'record layer failure'; Python 3.8 on macOS
+        # returns 'wrong version number' despite OpenSSL >= 3.1.
+        assert (
+            'record layer failure' in underlying_error_string
+            or 'wrong version number' in underlying_error_string
+        )
+    elif IS_ABOVE_OPENSSL10:
+        assert 'wrong version number' in underlying_error_string
+    else:  # pragma: no cover
+        assert 'unknown protocol' in underlying_error_string
 
 
 def test_http_over_https_no_data(mocker):

--- a/cheroot/test/test_ssl.py
+++ b/cheroot/test/test_ssl.py
@@ -527,9 +527,7 @@ def test_tls_client_auth(  # noqa: C901, WPS213  # FIXME
                 "'Remote end closed connection without response'))",
             )
 
-        assert any(e in err_text for e in expected_substrings), (
-            f'Unexpected error text: {err_text!r}'
-        )
+        assert any(e in err_text for e in expected_substrings)
 
 
 @pytest.mark.parametrize(  # noqa: C901  # FIXME
@@ -700,17 +698,9 @@ def test_https_over_http_error(http_server, ip_addr):
             f'{interface}:{port}',
         ).request('GET', '/')
     underlying_error_string = str(ssl_err.value)
-    if IS_ABOVE_OPENSSL31 and IS_WINDOWS:
-        # On Windows, the TCP reset (RST) is surfaced before OpenSSL processes
-        # the server's response, yielding 'wrong version number' rather than
-        # the usual 'record layer failure'. See CPython's own test_ssl.py:
-        # https://github.com/python/cpython/blob/\
-        # 1b9fe5c7226eccc8b269a7443148033080399f43\
-        # /Lib/test/test_ssl.py#L5705
-        assert 'wrong version number' in underlying_error_string
-    elif IS_ABOVE_OPENSSL31:
-        # Newer Python returns 'record layer failure'; Python 3.8 on macOS
-        # returns 'wrong version number' despite OpenSSL >= 3.1.
+    if IS_ABOVE_OPENSSL31:
+        # 'record layer failure' is typical, but Windows and macOS/Python 3.8
+        # yield 'wrong version number' instead.
         assert (
             'record layer failure' in underlying_error_string
             or 'wrong version number' in underlying_error_string

--- a/docs/changelog-fragments.d/828.contrib.rst
+++ b/docs/changelog-fragments.d/828.contrib.rst
@@ -1,0 +1,3 @@
+Fixed ``test_https_over_http_error`` failing on Windows with OpenSSL 3.1+,
+where the SSL error message is ``wrong version number`` rather than
+``record layer failure`` -- by :user:`julianz-`.


### PR DESCRIPTION
`test_https_over_http_error` started failing in the CI on Windows with Python 3.14 after recent GitHub Actions runner image updates bumped Python 3.14.5 → 3.14.6 and OpenSSL 3.6.2 → 3.6.3 (win25/20260614.167 deployed ~June 19, win22/20260616.203 deployed shortly after).

The test expects record layer failure when `IS_ABOVE_OPENSSL31` is `True` (OpenSSL > 3.1), but with Python 3.14.6 bundling OpenSSL 3.6.3 on Windows both windows-2025 and windows-2022 now return `wrong version number` instead. This is a known Windows behavior: the TCP reset is surfaced to userspace before OpenSSL fully processes the server's response, causing a different error code to be reported (documented in [CPython's own test_ssl.py](https://github.com/python/cpython/blob/1b9fe5c7226eccc8b269a7443148033080399f43/Lib/test/test_ssl.py#L5705)).

Linux is currently unaffected — Ubuntu 24.04 uses system OpenSSL 3.0.x, so `IS_ABOVE_OPENSSL31` is `False` there and the test falls through to the elif `IS_ABOVE_OPENSSL10` branch, which already expects `wrong version number`.

❓ **What kind of change does this PR introduce?**

* [x] 🐞 bug fix
* [ ] 🐣 feature
* [ ] 📋 docs update
* [ ] 📋 tests/coverage improvement
* [ ] 📋 refactoring
* [ ] 💥 other

📋 **What is the related issue number (starting with `#`)**

<!-- Are there any issues opened that will be resolved by merging this change? -->


❓ **What is the current behavior?** (You can also link to an open issue here)

CI errors:

```python-traceback
>       assert expected_substring in ssl_err.value.args[-1]
E       AssertionError: assert 'record layer failure' in '[SSL: WRONG_VERSION_NUMBER] wrong version number (_ssl.c:1082)'

```
e.g.

https://github.com/cherrypy/cheroot/actions/runs/27889445941/job/82595847403?pr=827



❓ **What is the new behavior (if this is a feature change)?**



📋 **Other information**:

Related past patches:
* #645
* #655
* https://github.com/cherrypy/cheroot/commit/4470ae9849c2d60898f18e0e92bd4b585657cad2
* https://github.com/cherrypy/cheroot/commit/04414124582c06e787b88dc5aae24a3ffc16e293

📋 **Contribution checklist:**

(If you're a first-timer, check out
[this guide on making great pull requests][making a lovely PR])

* [x] I wrote descriptive pull request text above
* [x] I think the code is well written
* [x] I wrote [good commit messages]
* [ ] I have [squashed related commits together][related squash] after
      the changes have been approved
* [ ] Unit tests for the changes exist
* [ ] Integration tests for the changes exist (if applicable)
* [x] I used the same coding conventions as the rest of the project
* [x] The new code doesn't generate linter offenses
* [x] Documentation reflects the changes
* [x] The PR relates to *only* one subject with a clear title
      and description in grammatically correct, complete sentences