### PR TITLE
Fix unservicable connection error logging

### DIFF
--- a/cheroot/server.py
+++ b/cheroot/server.py
@@ -1904,7 +1904,7 @@ class HTTPServer:
                 # We can't just raise an exception because that will kill this
                 # thread, and prevent 503 errors from being sent to future
                 # connections.
-                self.server.error_log(
+                self.error_log(
                     repr(ex),
                     level=logging.ERROR,
                     traceback=True,

--- a/cheroot/test/test_server.py
+++ b/cheroot/test/test_server.py
@@ -1,5 +1,6 @@
 """Tests for the HTTP server."""
 
+import logging
 import os
 import pathlib
 import queue
@@ -125,6 +126,47 @@ def test_stop_interrupts_serve():
 
     serve_thread.join(0.5)
     assert not serve_thread.is_alive()
+
+
+def test_unservicable_conn_logs_unexpected_response_errors(monkeypatch):
+    """Check that unexpected 503 response errors are logged."""
+    class Conn:
+        linger = False
+        close_calls = 0
+
+        def close(self):
+            self.close_calls += 1
+            httpserver.ready = False
+
+    httpserver = HTTPServer(
+        bind_addr=(ANY_INTERFACE_IPV4, EPHEMERAL_PORT),
+        gateway=Gateway,
+    )
+    test_exception = RuntimeError('unexpected 503 response error')
+    conn = Conn()
+    log_entries = []
+
+    def simple_response(_request, _status):
+        raise test_exception
+
+    def log_error(*args, **kwargs):
+        log_entries.append((args, kwargs))
+
+    httpserver.error_log = log_error
+    httpserver.ready = True
+    httpserver._unservicable_conns.put(conn)
+    monkeypatch.setattr(
+        'cheroot.server.HTTPRequest.simple_response',
+        simple_response,
+    )
+
+    httpserver._serve_unservicable()
+
+    assert log_entries == [
+        ((repr(test_exception),), {'level': logging.ERROR, 'traceback': True}),
+    ]
+    assert conn.linger is True
+    assert conn.close_calls == 1
 
 
 @pytest.mark.parametrize(

--- a/cheroot/test/test_server.py
+++ b/cheroot/test/test_server.py
@@ -130,6 +130,7 @@ def test_stop_interrupts_serve():
 
 def test_unservicable_conn_logs_unexpected_response_errors(monkeypatch):
     """Check that unexpected 503 response errors are logged."""
+
     class Conn:
         linger = False
         close_calls = 0

--- a/cheroot/test/test_server.py
+++ b/cheroot/test/test_server.py
@@ -130,22 +130,17 @@ def test_stop_interrupts_serve():
 
 def test_unservicable_conn_logs_unexpected_response_errors(monkeypatch):
     """Check that unexpected 503 response errors are logged."""
-
-    class Conn:
-        linger = False
-        close_calls = 0
-
-        def close(self):
-            self.close_calls += 1
-            httpserver.ready = False
-
     httpserver = HTTPServer(
         bind_addr=(ANY_INTERFACE_IPV4, EPHEMERAL_PORT),
         gateway=Gateway,
     )
     test_exception = RuntimeError('unexpected 503 response error')
-    conn = Conn()
+    close_calls = []
     log_entries = []
+
+    def close_conn():
+        close_calls.append(None)
+        httpserver.ready = False
 
     def simple_response(_request, _status):
         raise test_exception
@@ -153,6 +148,7 @@ def test_unservicable_conn_logs_unexpected_response_errors(monkeypatch):
     def log_error(*args, **kwargs):
         log_entries.append((args, kwargs))
 
+    conn = types.SimpleNamespace(linger=False, close=close_conn)
     httpserver.error_log = log_error
     httpserver.ready = True
     httpserver._unservicable_conns.put(conn)
@@ -167,7 +163,7 @@ def test_unservicable_conn_logs_unexpected_response_errors(monkeypatch):
         ((repr(test_exception),), {'level': logging.ERROR, 'traceback': True}),
     ]
     assert conn.linger is True
-    assert conn.close_calls == 1
+    assert close_calls == [None]
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
❓ **What kind of change does this PR introduce?**

* [x] 🐞 bug fix
* [ ] 🐣 feature
* [ ] 📋 docs update
* [x] 📋 tests/coverage improvement
* [ ] 📋 refactoring
* [ ] 💥 other

📋 **What is the related issue number (starting with `#`)**

Resolves #797

❓ **What is the current behavior?**

`HTTPServer._serve_unservicable()` calls `self.server.error_log()` when `HTTPRequest.simple_response()` raises an unexpected exception, but `HTTPServer` does not have a `server` attribute. That means the 503 handler's error logging path raises another exception instead of logging the original failure.

❓ **What is the new behavior?**

The 503 handler now calls `self.error_log()`, matching other `HTTPServer` logging paths. A focused regression test covers the unexpected-error branch and verifies that the connection is still marked for linger/close.

📋 **Other information**:

Verification:

* `python -m py_compile cheroot/server.py cheroot/test/test_server.py`
* `.\.venv\Scripts\python.exe -m pytest cheroot/test/test_server.py -k unservicable -q --no-cov`
* `.\.venv\Scripts\python.exe -m pytest cheroot/test/test_server.py::test_stop_interrupts_serve cheroot/test/test_server.py::test_unservicable_conn_logs_unexpected_response_errors -q --no-cov`

The targeted pytest selection also passes under the repository config, but the repo-wide coverage threshold fails when only this single test is selected; the `--no-cov` runs above verify the regression locally.

📋 **Contribution checklist:**

* [x] I wrote descriptive pull request text above
* [x] I think the code is well written
* [x] I wrote [good commit messages]
* [ ] I have [squashed related commits together][related squash] after the changes have been approved
* [x] Unit tests for the changes exist
* [ ] Integration tests for the changes exist (if applicable)
* [x] I used the same coding conventions as the rest of the project
* [x] The new code doesn't generate linter offenses
* [x] Documentation reflects the changes
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences

[good commit messages]: http://chris.beams.io/posts/git-commit/
[making a lovely PR]: https://mtlynch.io/code-review-love/
[related squash]: https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit