### PR TITLE
Fix HTTPConnection.communicate() to pass server proxy and strict mode settings

### DIFF
--- a/cheroot/server.py
+++ b/cheroot/server.py
@@ -1306,7 +1306,12 @@ class HTTPConnection:
         """
         request_seen = False
         try:
-            req = self.RequestHandlerClass(self.server, self)
+            req = self.RequestHandlerClass(
+                self.server,
+                self,
+                proxy_mode=self.server.proxy_mode,
+                strict_mode=self.server.strict_mode,
+            )
             req.parse_request()
             if self.server.stats['Enabled']:
                 self.requests_seen += 1

--- a/cheroot/test/test_server.py
+++ b/cheroot/test/test_server.py
@@ -20,7 +20,7 @@ import requests_unixsocket
 from pypytools.gc.custom import DefaultGc
 
 from .._compat import IS_LINUX, IS_MACOS, IS_WINDOWS, SYS_PLATFORM, bton, ntob
-from ..server import IS_UID_GID_RESOLVABLE, Gateway, HTTPServer
+from ..server import IS_UID_GID_RESOLVABLE, Gateway, HTTPConnection, HTTPServer
 from ..testing import (
     ANY_INTERFACE_IPV4,
     ANY_INTERFACE_IPV6,
@@ -125,6 +125,58 @@ def test_stop_interrupts_serve():
 
     serve_thread.join(0.5)
     assert not serve_thread.is_alive()
+
+
+def test_communicate_uses_server_proxy_and_strict_mode():
+    """Check that parsed requests inherit proxy/strict mode from the server."""
+    httpserver = HTTPServer(
+        bind_addr=(ANY_INTERFACE_IPV4, EPHEMERAL_PORT),
+        gateway=Gateway,
+    )
+    request_init_args = []
+
+    class CapturingHTTPRequest:
+        """Capture request constructor args used during communication."""
+
+        def __init__(
+            self,
+            server,
+            conn,
+            proxy_mode=False,
+            strict_mode=True,
+        ):
+            request_init_args.append(
+                {
+                    'server': server,
+                    'conn': conn,
+                    'proxy_mode': proxy_mode,
+                    'strict_mode': strict_mode,
+                },
+            )
+            self.ready = False
+
+        def parse_request(self):
+            return None
+
+    conn = HTTPConnection(
+        httpserver,
+        types.SimpleNamespace(),
+        makefile=lambda _sock, _mode, _bufsize: types.SimpleNamespace(),
+    )
+    conn.RequestHandlerClass = CapturingHTTPRequest
+    httpserver.proxy_mode = True
+    httpserver.strict_mode = False
+
+    assert conn.communicate() is False
+
+    assert request_init_args == [
+        {
+            'server': httpserver,
+            'conn': conn,
+            'proxy_mode': True,
+            'strict_mode': False,
+        },
+    ]
 
 
 @pytest.mark.parametrize(

--- a/docs/changelog-fragments.d/831.bugfix.rst
+++ b/docs/changelog-fragments.d/831.bugfix.rst
@@ -1,0 +1,1 @@
+Preserved server proxy and strict mode settings when parsing requests on accepted connections.


### PR DESCRIPTION
❓ **What kind of change does this PR introduce?**

* [x] 🐞 bug fix
* [ ] 🐣 feature
* [ ] 📋 docs update
* [x] 📋 tests/coverage improvement
* [ ] 📋 refactoring
* [ ] 💥 other

📋 **What is the related issue number (starting with `#`)**

Resolves #823.

❓ **What is the current behavior?** (You can also link to an open issue here)

`HTTPConnection.communicate()` initialized request handlers with default `proxy_mode` and `strict_mode` values instead of the server's configured values.

❓ **What is the new behavior (if this is a feature change)?**

`HTTPConnection.communicate()` now passes `proxy_mode=self.server.proxy_mode` and `strict_mode=self.server.strict_mode` when constructing the request handler.

📋 **Other information**:

Added `docs/changelog-fragments.d/831.bugfix.rst`.

Testing:

* `.venv\Scripts\python.exe -m pytest --no-cov -n 0 cheroot/test/test_server.py -k communicate_uses_server_proxy_and_strict_mode`

📋 **Contribution checklist:**

* [x] I wrote descriptive pull request text above
* [x] I think the code is well written
* [x] I wrote good commit messages
* [x] I have squashed related commits together after the changes have been approved
* [x] Unit tests for the changes exist
* [ ] Integration tests for the changes exist (if applicable)
* [x] I used the same coding conventions as the rest of the project
* [x] The new code doesn't generate linter offenses
* [x] Documentation reflects the changes
* [x] The PR relates to only one subject with a clear title and description in grammatically correct, complete sentences