### PR TITLE
Reject NUL bytes in HTTP request lines

### DIFF
--- a/cheroot/server.py
+++ b/cheroot/server.py
@@ -800,6 +800,13 @@ class HTTPRequest:
             )
             return False
 
+        if b'\x00' in request_line:
+            self.simple_response(
+                '400 Bad Request',
+                'Malformed Request-Line',
+            )
+            return False
+
         try:
             method, uri, req_protocol = request_line.strip().split(SPACE, 2)
             if not req_protocol.startswith(b'HTTP/'):

--- a/cheroot/test/test_core.py
+++ b/cheroot/test/test_core.py
@@ -315,6 +315,11 @@ def test_large_request(test_client_with_defaults):
             b'Malformed Request-Line',
         ),
         (
+            b'GET /\x00 HTTP/1.1',  # NUL byte
+            HTTP_BAD_REQUEST,
+            b'Malformed Request-Line',
+        ),
+        (
             b'GET / HTTPS/1.1',  # invalid proto
             HTTP_BAD_REQUEST,
             b'Malformed Request-Line: bad protocol',

--- a/docs/changelog-fragments.d/832.bugfix.rst
+++ b/docs/changelog-fragments.d/832.bugfix.rst
@@ -1,0 +1,1 @@
+Rejected HTTP request lines containing NUL bytes as malformed requests.


### PR DESCRIPTION
❓ **What kind of change does this PR introduce?**

* [x] 🐞 bug fix
* [ ] 🐣 feature
* [ ] 📋 docs update
* [x] 📋 tests/coverage improvement
* [ ] 📋 refactoring
* [ ] 💥 other

📋 **What is the related issue number (starting with `#`)**

Related to #201.

❓ **What is the current behavior?** (You can also link to an open issue here)

HTTP request lines containing embedded NUL bytes could reach the request-line parser instead of being rejected explicitly as malformed input.

❓ **What is the new behavior (if this is a feature change)?**

Cheroot now rejects request lines containing NUL bytes with `400 Bad Request` before splitting the request line. The malformed request-line test matrix covers the NUL-byte case.

📋 **Other information**:

Added `docs/changelog-fragments.d/832.bugfix.rst`.

Testing:

* `.venv\Scripts\python.exe -m pytest --no-cov -n 0 cheroot/test/test_core.py -k malformed_request_line`

📋 **Contribution checklist:**

* [x] I wrote descriptive pull request text above
* [x] I think the code is well written
* [x] I wrote good commit messages
* [x] I have squashed related commits together after the changes have been approved
* [x] Unit tests for the changes exist
* [ ] Integration tests for the changes exist (if applicable)
* [x] I used the same coding conventions as the rest of the project
* [x] The new code doesn't generate linter offenses
* [x] Documentation reflects the changes
* [x] The PR relates to only one subject with a clear title and description in grammatically correct, complete sentences