### PR TITLE
Reject invalid HTTP method token characters

### DIFF
--- a/cheroot/server.py
+++ b/cheroot/server.py
@@ -162,6 +162,7 @@ ASTERISK = b'*'
 FORWARD_SLASH = b'/'
 QUOTED_SLASH = b'%2F'
 QUOTED_SLASH_REGEX = re.compile(b''.join((b'(?i)', QUOTED_SLASH)))
+HTTP_TOKEN_RE = re.compile(rb'^[!#$%&\'*+\-.^_`|~0-9A-Za-z]+$')
 
 
 _STOPPING_FOR_INTERRUPT = Exception()  # sentinel used during shutdown
@@ -824,6 +825,10 @@ class HTTPRequest:
                 return False
         except (ValueError, IndexError):
             self.simple_response('400 Bad Request', 'Malformed Request-Line')
+            return False
+
+        if not HTTP_TOKEN_RE.match(method):
+            self.simple_response('400 Bad Request', 'Malformed method name')
             return False
 
         self.uri = uri

--- a/cheroot/test/test_core.py
+++ b/cheroot/test/test_core.py
@@ -420,6 +420,17 @@ def test_garbage_in(test_client):
             raise
 
 
+def test_invalid_character_in_http_method(test_client):
+    """Check that methods with invalid token characters are rejected."""
+    c = test_client.get_connection()
+    c._output(b'GE(T / HTTP/1.1\r\nHost: localhost\r\n\r\n')
+    c._send_output()
+    response = _get_http_response(c, method='GET')
+    response.begin()
+    assert response.status == HTTP_BAD_REQUEST
+    c.close()
+
+
 class CloseController:
     """Controller for testing the close callback."""
 

--- a/docs/changelog-fragments.d/833.bugfix.rst
+++ b/docs/changelog-fragments.d/833.bugfix.rst
@@ -1,0 +1,1 @@
+Rejected HTTP methods containing characters that are invalid in HTTP tokens.


### PR DESCRIPTION
❓ **What kind of change does this PR introduce?**

* [x] 🐞 bug fix
* [ ] 🐣 feature
* [ ] 📋 docs update
* [x] 📋 tests/coverage improvement
* [ ] 📋 refactoring
* [ ] 💥 other

📋 **What is the related issue number (starting with `#`)**

Closes #715.

❓ **What is the current behavior?** (You can also link to an open issue here)

HTTP request methods containing characters outside the HTTP token grammar could be accepted after parsing the request line.

❓ **What is the new behavior (if this is a feature change)?**

Cheroot now validates parsed HTTP methods against the HTTP token character set and rejects methods containing invalid token characters with `400 Bad Request`.

📋 **Other information**:

Added `docs/changelog-fragments.d/833.bugfix.rst`.

Testing:

* `.venv\Scripts\python.exe -m pytest --no-cov -n 0 cheroot/test/test_core.py -k "malformed_http_method or invalid_character_in_http_method"`

📋 **Contribution checklist:**

* [x] I wrote descriptive pull request text above
* [x] I think the code is well written
* [x] I wrote good commit messages
* [x] I have squashed related commits together after the changes have been approved
* [x] Unit tests for the changes exist
* [ ] Integration tests for the changes exist (if applicable)
* [x] I used the same coding conventions as the rest of the project
* [x] The new code doesn't generate linter offenses
* [x] Documentation reflects the changes
* [x] The PR relates to only one subject with a clear title and description in grammatically correct, complete sentences