### PR TITLE
Reject non-numeric Content-Length header values

### DIFF
--- a/cheroot/server.py
+++ b/cheroot/server.py
@@ -163,6 +163,13 @@ FORWARD_SLASH = b'/'
 QUOTED_SLASH = b'%2F'
 QUOTED_SLASH_REGEX = re.compile(b''.join((b'(?i)', QUOTED_SLASH)))
 
+# ``Content-Length`` is defined as ``1*DIGIT`` by
+# https://datatracker.ietf.org/doc/html/rfc9110#section-8.6. ``int()``
+# additionally tolerates surrounding whitespace, a leading sign and
+# digit-separating underscores (e.g. ``1_0`` -> ``10``), none of which are
+# valid, so the raw value has to be validated before it is parsed.
+NUMERIC_REGEX = re.compile(rb'[0-9]+')
+
 
 _STOPPING_FOR_INTERRUPT = Exception()  # sentinel used during shutdown
 
@@ -1008,14 +1015,17 @@ class HTTPRequest:
 
         mrbs = self.server.max_request_body_size
 
-        try:
-            cl = int(self.inheaders.get(b'Content-Length', 0))
-        except ValueError:
+        raw_content_length = self.inheaders.get(b'Content-Length', b'0')
+        # ``int()`` silently accepts values that are not valid ``1*DIGIT``
+        # strings (e.g. ``b'1_0'``, ``b'+10'`` or surrounding whitespace), so
+        # the raw value has to be checked against the grammar first.
+        if NUMERIC_REGEX.fullmatch(raw_content_length) is None:
             self.simple_response(
                 '400 Bad Request',
                 'Malformed Content-Length Header.',
             )
             return False
+        cl = int(raw_content_length)
 
         if mrbs and cl > mrbs:
             self.simple_response(

--- a/cheroot/test/test_conn.py
+++ b/cheroot/test/test_conn.py
@@ -1437,13 +1437,24 @@ def test_Content_Length_in(test_client):
     conn.close()
 
 
-def test_Content_Length_not_int(test_client):
-    """Test that malicious Content-Length header returns 400."""
+@pytest.mark.parametrize(
+    'content_length_value',
+    (
+        'not-an-integer',
+        # `int()` accepts these, but they are not valid `1*DIGIT` values
+        # per :rfc:`9110#section-8.6`, so they must be rejected (#738).
+        '1_0',  # a digit-separating underscore
+        '+10',  # a leading sign
+        '0x10',  # a hexadecimal literal
+    ),
+)
+def test_Content_Length_not_int(test_client, content_length_value):
+    """Test that a malformed Content-Length header returns 400."""
     status_line, _actual_headers, actual_resp_body = test_client.post(
         '/upload',
         headers=[
             ('Content-Type', 'text/plain'),
-            ('Content-Length', 'not-an-integer'),
+            ('Content-Length', content_length_value),
         ],
     )
     actual_status = int(status_line[:3])

--- a/docs/changelog-fragments.d/738.bugfix.rst
+++ b/docs/changelog-fragments.d/738.bugfix.rst
@@ -1,0 +1,6 @@
+Started rejecting ``Content-Length`` request header values that are not
+valid ``1*DIGIT`` strings with a ``400 Bad Request`` response. Previously,
+values such as ``1_0`` (a digit-separating underscore) or ``+10`` (a leading
+sign) were silently accepted by :py:func:`int` and parsed as ``10``.
+
+-- by :user:`apoorvdarshan`


### PR DESCRIPTION
Fixes #738

## Root cause

When reading request headers, `HTTPRequest.read_request_headers()` parsed the
`Content-Length` value with a bare `int()`:

```python
cl = int(self.inheaders.get(b'Content-Length', 0))
```

`int()` is more permissive than the `Content-Length` grammar, which is
`1*DIGIT` per [RFC 9110 §8.6](https://datatracker.ietf.org/doc/html/rfc9110#section-8.6).
In particular `int()` silently accepts digit-separating underscores
(`int('1_0') == 10`), a leading `+`/`-` sign, and surrounding whitespace. The
existing `try/except ValueError` only caught values that `int()` itself
rejects (e.g. `not-an-integer`), so malformed-but-parseable values slipped
through and were used as the body length.

## Reproduction

Minimal WSGI server that echoes the received body length, sending a POST with a
2-byte body but a malformed `Content-Length`:

```python
import socket, threading
from cheroot import wsgi

def app(environ, start_response):
    n = int(environ.get('CONTENT_LENGTH', 0) or 0)
    body = environ['wsgi.input'].read(n)
    start_response('200 OK', [('Content-Type', 'text/plain')])
    return [b'read %d bytes' % len(body)]

server = wsgi.Server(('127.0.0.1', 0), app)
server.prepare()
host, port = server.bind_addr
threading.Thread(target=server.serve, daemon=True).start()

def send(cl):
    s = socket.create_connection((host, port), timeout=2)
    s.sendall(
        b'POST /u HTTP/1.1\r\nHost: %s\r\nContent-Length: %s\r\n'
        b'Connection: close\r\n\r\nAB' % (host.encode(), cl)
    )
    data = b''
    try:
        while True:
            chunk = s.recv(4096)
            if not chunk:
                break
            data += chunk
    except socket.timeout:
        pass
    s.close()
    print('Content-Length=%-6r ->' % cl, data.split(b'\r\n', 1)[0])

for cl in (b'2', b'1_0', b'+2'):
    send(cl)
```

**Wrong output (before the fix):**

```
Content-Length=b'2'   -> b'HTTP/1.1 200 OK'
Content-Length=b'1_0' -> b''
Content-Length=b'+2'  -> b'HTTP/1.1 200 OK'
```

`1_0` was parsed as `10`; the server then blocked waiting for 10 body bytes
that never arrived (only 2 were sent), so no response came back before the
client timed out. `+2` was parsed as `2` and accepted outright. Both should
have been rejected.

**Corrected output (after the fix):**

```
Content-Length=b'2'   -> b'HTTP/1.1 200 OK'
Content-Length=b'1_0' -> b'HTTP/1.1 400 Bad Request'
Content-Length=b'+2'  -> b'HTTP/1.1 400 Bad Request'
```

## Fix

Validate the raw header value against `[0-9]+` (a module-level compiled
`NUMERIC_REGEX`) before calling `int()`, and reuse the existing
`400 Bad Request` / `Malformed Content-Length Header.` response path when it
does not match. The change is confined to the one parse site in
`read_request_headers()`. The second `int(Content-Length)` in `respond()` is
reached only after `read_request_headers()` has already returned successfully,
so it never sees an unvalidated value. A default of `b'0'` preserves the
existing behavior for requests without a `Content-Length` header.

## Tests

Parametrized the existing `test_Content_Length_not_int` in
`cheroot/test/test_conn.py` to also cover `1_0`, `+10` and `0x10`. On the
unmodified code the `1_0` and `+10` cases fail (the server returns `408`
after blocking on the never-arriving body instead of `400`); with the fix all
four cases return `400`.

```
$ python -m pytest cheroot/test/test_conn.py::test_Content_Length_not_int
4 passed
```

The surrounding suites pass as well (`test_conn.py`, `test_core.py`,
`test_wsgi.py`, `test_server.py`), and `flake8` reports no new offenses on the
changed files. A changelog fragment (`docs/changelog-fragments.d/738.bugfix.rst`)
is included.

Disclosure: prepared with AI assistance; reviewed and verified locally.
