### PR TITLE
Fix test_tls_client_auth for Windows with Python 3.14 and OpenSSL 3.4+

### DIFF
--- a/cheroot/test/test_ssl.py
+++ b/cheroot/test/test_ssl.py
@@ -486,10 +486,11 @@ def test_tls_client_auth(  # noqa: C901, WPS213  # FIXME
                     'OSError("(10054, \'WSAECONNRESET\')",))',
                     "('Connection aborted.', "
                     'error("(10054, \'WSAECONNRESET\')",))',
+                    # Truncated string matches both 2-arg (Python 3.14+/OpenSSL 3.4+)
+                    # and 5-arg forms. See https://github.com/cherrypy/cheroot/pull/838
                     "('Connection aborted.', "
-                    'ConnectionResetError(10054, '
-                    "'An existing connection was forcibly closed "
-                    "by the remote host', None, 10054, None))",
+                    "ConnectionResetError(10054, 'An existing connection "
+                    "was forcibly closed by the remote host'",
                     "('Connection aborted.', "
                     'error(10054, '
                     "'An existing connection was forcibly closed "


### PR DESCRIPTION
On Windows, OpenSSL 3.4 (bundled with Python 3.14) changed how syscall errors are reported, causing `ConnectionResetError` to be raised with 2 arguments instead of 5.

## What kind of change does this PR introduce?

* [x] 🐞 bug fix
* [ ] 🐣 feature
* [ ] 📋 docs update
* [ ] 📋 tests/coverage improvement
* [ ] 📋 refactoring
* [ ] 💥 other

## What do these changes do?

Eliminate the error that sometimes affects `test_tls_client_auth()` under Windows. See e.g. [here](https://github.com/cherrypy/cheroot/actions/runs/29217454416/job/86716151926?pr=828#step:15:344)


<!-- Please give a short brief about these changes. -->

The issue arose because of a change in OpenSSL 3.4 which on Windows came in with Python 3.14.

OpenSSL 3.4 started putting system errors into the error queue via `ERR_LIB_SYS`, setting `e = ERR_peek_last_error()` to non-zero where it was previously 0. When it was 0, CPython would check in [`_ssl.c`](https://github.com/python/cpython/blob/3.14/Modules/_ssl.c#L689) for Windows where it handles the error with:

```
if (e == 0) {
                ...
                #ifdef MS_WINDOWS
                                if (err.ws) {
                                    return PyErr_SetFromWindowsErr(err.ws);
                                }
                #endif
```

Thus the code prior to OpenSSL 3.4 used to call the Windows specific `PyErr_SetFromWindowsErr()` which sets a Python exception that eventually surfaces via `repr()` as a string including 5 args. 

With OpenSSL 3.4+, `e` is non-zero, so the code takes a different branch. CPython [PR #127361](https://github.com/python/cpython/pull/127361) added a check there: if OpenSSL identifies the error as coming from the OS/syscall layer (`ERR_GET_LIB(e) == ERR_LIB_SYS`), Python raises `OSError` via `PyErr_SetFromErrno()` rather than leaving it as a generic `SSLError`. In this test case the syscall error is `ConnectionResetError` (Windows error 10054). `PyErr_SetFromErrno()` sets 2 args, whereas the old `PyErr_SetFromWindowsErr()` path set 5.

The fix here is simply to truncate the `ConnectionResetError`  error string so it matches regardless of whether 2 or 5 args are present.

## Are there changes in behavior for the user?

<!-- Outline any notable behavior for the end users. -->
None.

## Is it a substantial burden for the maintainers to support this?
No

## Related issue number
Briefly mentioned here: #828#issuecomment-5001157956

## Checklist

* [x] I wrote descriptive pull request text above
* [x] The PR relates to *only* one subject with a clear title
      and description in grammatically correct, complete sentences
* [x] I think the code is well written
* [x] Unit tests for the changes exist
* [ ] Integration tests for the changes exist (if applicable)
* [x] I used the same coding conventions as the rest of the project
* [x] The new code doesn't generate linter offenses
* [ ] Project documentation (in `docs/`) and inline docstrings reflect the changes
* [x] My commits each have a descriptive title and a body explaining the why
      (see [good commit messages])
* [x] I have added a [change log entry]
      (can be done once the PR number is known; alternatively, you can
      use a related issue number if one exists)
* [ ] I'm planning to [squash related commits] together before final merge
* [x] I have read the [contribution guide] and the
      [code of conduct][CoC]
