### PR TITLE
Handle read() returning None on a non-blocking socket

### DIFF
--- a/cheroot/makefile.py
+++ b/cheroot/makefile.py
@@ -46,7 +46,11 @@ class StreamReader(io.BufferedReader):
     def read(self, *args, **kwargs):
         """Capture bytes read."""
         val = super().read(*args, **kwargs)
-        self.bytes_read += len(val)
+        # A non-blocking socket with nothing available yet can make the
+        # underlying BufferedReader return None instead of b''. That's
+        # documented io.RawIOBase behavior, so don't choke on it here.
+        if val is not None:
+            self.bytes_read += len(val)
         return val
 
     def has_data(self):

--- a/cheroot/test/test_makefile.py
+++ b/cheroot/test/test_makefile.py
@@ -1,5 +1,7 @@
 """Tests for :py:mod:`cheroot.makefile`."""
 
+import errno
+
 from cheroot import makefile
 
 
@@ -9,9 +11,12 @@ class MockSocket:
     def __init__(self):
         """Initialize :py:class:`MockSocket`."""
         self.messages = []
+        self.would_block = False
 
     def recv_into(self, buf):
         """Simulate ``recv_into`` for Python 3."""
+        if self.would_block:
+            raise BlockingIOError(errno.EWOULDBLOCK, 'would block')
         if not self.messages:
             return 0
         msg = self.messages.pop(0)
@@ -42,6 +47,20 @@ def test_bytes_read():
     rfile = makefile.MakeFile(sock, 'r')
     rfile.read()
     assert rfile.bytes_read == 3
+
+
+def test_read_on_nonblocking_socket_with_no_data():
+    """Reader should return ``None``, not crash, if nothing is available yet.
+
+    A non-blocking socket's ``read()`` can return ``None`` per the
+    documented ``io.RawIOBase`` contract when no data is available; this
+    used to blow up on ``len(None)``. Ref: cherrypy/cheroot#278
+    """
+    sock = MockSocket()
+    sock.would_block = True
+    rfile = makefile.MakeFile(sock, 'r')
+    assert rfile.read(256) is None
+    assert rfile.bytes_read == 0
 
 
 def test_bytes_written():


### PR DESCRIPTION
Fixes #278.

When cheroot serves with a non-blocking socket (`timeout=0`), `io.BufferedReader.read()` can legitimately return `None` instead of `b''` when there's nothing to read yet - that's the documented contract for `io.RawIOBase` in non-blocking mode, not an error condition. `StreamReader.read()` overrides `read()` to track `bytes_read` but didn't account for this, so it crashed with `TypeError: object of type 'NoneType' has no len()` any time a non-blocking read came back with nothing available.

I confirmed this is still live on current `main`, not just a Python 2 quirk as the original report speculated - reproduced it with a real non-blocking socket pair (no data sent yet, read() blows up immediately).

The fix just skips the byte count update when `val` is `None` and returns it unchanged, so the rest of the io stack still sees the documented would-block signal it already knows how to handle.

Added a regression test using the existing `MockSocket` pattern (its `recv_into` now raises `BlockingIOError` to simulate the non-blocking-no-data case) - fails on unmodified `makefile.py` with the exact same TypeError from the issue, passes with the fix. Ran the full `test_makefile.py`, `test_conn.py`, and `test_wsgi.py` suites before and after, all green.